### PR TITLE
WIP: Large Smt

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,3 +7,8 @@ default-filter = 'not test(merkle::smt::full::concurrent)'
 failure-output = "immediate-final"
 fail-fast = false
 default-filter = 'test(merkle::smt::full::concurrent)'
+
+[profile.large-smt]
+failure-output = "immediate-final"
+fail-fast = false
+default-filter = 'test(merkle::smt::full::large)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,7 @@
 [profile.default]
 failure-output = "immediate-final"
 fail-fast = false
-default-filter = 'not test(merkle::smt::full::concurrent)'
+default-filter = 'not (test(merkle::smt::full::concurrent) or test(merkle::smt::full::large) or binary(rocksdb_large_smt))'
 
 [profile.smt-concurrent]
 failure-output = "immediate-final"
@@ -11,4 +11,4 @@ default-filter = 'test(merkle::smt::full::concurrent)'
 [profile.large-smt]
 failure-output = "immediate-final"
 fail-fast = false
-default-filter = 'test(merkle::smt::full::large)'
+default-filter = '(test(merkle::smt::full::large) or binary(rocksdb_large_smt))'

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cmake-build-*
 tests.txt
 *.mdb
 bench_large_smt
+miden-crypto/test_smt

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cmake-build-*
 # Proptest
 tests.txt
 *.mdb
+bench_large_smt

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cmake-build-*
 
 # Proptest
 tests.txt
+*.mdb

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@ cmake-build-*
 # Proptest
 tests.txt
 *.mdb
-bench_large_smt
-miden-crypto/test_smt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,10 +98,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "blake3"
@@ -130,6 +142,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -298,6 +316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +357,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +393,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "generic-array"
@@ -416,6 +472,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "heed"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a56c94661ddfb51aa9cdfbf102cfcc340aa69267f95ebccc4af08d7c530d393"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +520,145 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "is-terminal"
@@ -500,6 +733,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+
+[[package]]
+name = "lmdb-master-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864808e0b19fb6dd3b70ba94ee671b82fce17554cf80aeb0a155c65bb08027df"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +773,7 @@ dependencies = [
  "getrandom 0.3.1",
  "glob",
  "hashbrown",
+ "heed",
  "hex",
  "num",
  "num-complex",
@@ -626,6 +877,64 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "plotters"
@@ -890,6 +1199,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "smallvec"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1231,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -924,6 +1271,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -953,6 +1310,29 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1060,6 +1440,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1463,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1189,6 +1591,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1640,49 @@ name = "zerocopy-derive"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,12 +98,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bindgen"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "serde",
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -111,9 +140,6 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "blake3"
@@ -144,10 +170,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cast"
@@ -164,6 +194,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -197,6 +236,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -316,15 +366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,26 +398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "doxygen-rs"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
-dependencies = [
- "phf",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,15 +414,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "generic-array"
@@ -472,44 +484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "heed"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a56c94661ddfb51aa9cdfbf102cfcc340aa69267f95ebccc4af08d7c530d393"
-dependencies = [
- "bitflags",
- "byteorder",
- "heed-traits",
- "heed-types",
- "libc",
- "lmdb-master-sys",
- "once_cell",
- "page_size",
- "serde",
- "synchronoise",
- "url",
-]
-
-[[package]]
-name = "heed-traits"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
-
-[[package]]
-name = "heed-types"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
-dependencies = [
- "bincode",
- "byteorder",
- "heed-traits",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,145 +494,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "is-terminal"
@@ -721,10 +556,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "libm"
@@ -733,20 +590,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
-name = "litemap"
-version = "0.7.5"
+name = "librocksdb-sys"
+version = "0.17.1+9.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
+dependencies = [
+ "bindgen 0.69.5",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
 
 [[package]]
-name = "lmdb-master-sys"
-version = "0.2.5"
+name = "libz-sys"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864808e0b19fb6dd3b70ba94ee671b82fce17554cf80aeb0a155c65bb08027df"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
- "doxygen-rs",
- "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -754,6 +620,16 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -773,7 +649,6 @@ dependencies = [
  "getrandom 0.3.1",
  "glob",
  "hashbrown",
- "heed",
  "hex",
  "num",
  "num-complex",
@@ -782,6 +657,7 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "rayon",
+ "rocksdb",
  "seq-macro",
  "serde",
  "sha3",
@@ -790,6 +666,22 @@ dependencies = [
  "winter-math",
  "winter-rand-utils",
  "winter-utils",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -879,62 +771,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "page_size"
-version = "0.6.0"
+name = "pkg-config"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1124,6 +964,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rocksdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,24 +1061,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
-name = "smallvec"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,26 +1075,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synchronoise"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
-dependencies = [
- "crossbeam-queue",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1271,16 +1095,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -1312,33 +1126,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "url"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1440,22 +1237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,12 +1244,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1591,42 +1366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,44 +1386,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "bindgen 0.71.1",
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,10 +410,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "generic-array"
@@ -432,8 +456,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -616,6 +642,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +682,7 @@ dependencies = [
  "cc",
  "clap",
  "criterion",
+ "flume",
  "getrandom 0.3.1",
  "glob",
  "hashbrown",
@@ -673,6 +710,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.15",
+]
 
 [[package]]
 name = "nom"
@@ -1007,6 +1053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "seq-macro"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1111,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,25 +112,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn",
 ]
@@ -246,7 +228,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -408,6 +389,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flume"
@@ -600,16 +597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,13 +608,12 @@ version = "0.17.1+9.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "libc",
  "libz-sys",
  "lz4-sys",
- "zstd-sys",
 ]
 
 [[package]]
@@ -640,6 +626,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -698,6 +690,7 @@ dependencies = [
  "seq-macro",
  "serde",
  "sha3",
+ "tempfile",
  "thiserror",
  "winter-crypto",
  "winter-math",
@@ -1026,10 +1019,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
+name = "rustix"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -1136,6 +1136,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1444,15 +1457,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "bindgen 0.71.1",
- "cc",
- "pkg-config",
 ]

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ test-no-std: ## Run tests with `no-default-features` (std)
 test-smt-concurrent: ## Run only concurrent SMT tests
 	$(DEBUG_OVERFLOW_INFO) cargo nextest run --profile smt-concurrent --release --all-features
 
+.PHONY: test-large-smt
+test-large-smt: ## Run only concurrent SMT tests
+	$(DEBUG_OVERFLOW_INFO) cargo nextest run --success-output immediate  --profile large-smt --release --all-features
+
 .PHONY: test
 test: test-default test-smt-hashmaps test-no-std ## Run all tests except concurrent SMT tests
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-smt-concurrent: ## Run only concurrent SMT tests
 
 .PHONY: test-large-smt
 test-large-smt: ## Run only concurrent SMT tests
-	$(DEBUG_OVERFLOW_INFO) cargo nextest run --success-output immediate  --profile large-smt --release --all-features
+	$(DEBUG_OVERFLOW_INFO) cargo nextest run --success-output immediate  --profile large-smt --release --all-features --test-threads=1
 
 .PHONY: test
 test: test-default test-smt-hashmaps test-no-std ## Run all tests except concurrent SMT tests

--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,11 @@ test-smt-concurrent: ## Run only concurrent SMT tests
 	$(DEBUG_OVERFLOW_INFO) cargo nextest run --profile smt-concurrent --release --all-features
 
 .PHONY: test-large-smt
-test-large-smt: ## Run only concurrent SMT tests
-	$(DEBUG_OVERFLOW_INFO) cargo nextest run --success-output immediate  --profile large-smt --release --all-features --test-threads=1
+test-large-smt: ## Run only large SMT tests
+	$(DEBUG_OVERFLOW_INFO) cargo nextest run --success-output immediate  --profile large-smt --release --all-features
 
 .PHONY: test
-test: test-default test-smt-hashmaps test-no-std ## Run all tests except concurrent SMT tests
+test: test-default test-smt-hashmaps test-no-std test-large-smt ## Run all tests except concurrent SMT tests
 
 # --- checking ------------------------------------------------------------------------------------
 
@@ -98,6 +98,18 @@ bench: ## Run crypto benchmarks
 .PHONY: bench-smt-concurrent
 bench-smt-concurrent: ## Run SMT benchmarks with concurrent feature
 	cargo run --release --features concurrent,executable -- --size 1000000
+
+.PHONY: bench-large-smt-memory
+bench-large-smt-memory: ## Run large SMT benchmarks with memory storage
+	cargo run --release --features concurrent,smt_hashmaps,executable -- --size 1000000
+
+.PHONY: bench-large-smt-rocksdb
+bench-large-smt-rocksdb: ## Run large SMT benchmarks with rocksdb storage
+	cargo run --release --features concurrent,smt_hashmaps,rocksdb,executable -- --size 1000000
+
+.PHONY: bench-large-smt-rocksdb-open
+bench-large-smt-rocksdb-open: ## Run large SMT benchmarks with rocksdb storage and open existing database
+	cargo run --release --features concurrent,smt_hashmaps,rocksdb,executable -- --open
 
 # --- fuzzing --------------------------------------------------------------------------------
 

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -65,13 +65,13 @@ std = [
 blake3 = { version = "1.6", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
 hashbrown = { version = "0.15", optional = true, features = ["serde"] }
-heed = { version = "0.22.0" }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.9", default-features = false }
 rand_core = { version = "0.9", default-features = false }
 rand-utils = { version = "0.12", package = "winter-rand-utils", optional = true }
 rayon = { version = "1.10", optional = true }
+rocksdb = { version = "0.23.0" }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 sha3 = { version = "0.10", default-features = false }
 thiserror = { version = "2.0", default-features = false }

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -46,7 +46,7 @@ harness = false
 
 [features]
 concurrent = ["dep:rayon", "hashbrown?/rayon"]
-default = ["std", "concurrent"]
+default = ["std", "concurrent", "serde"]
 executable = ["dep:clap", "dep:rand-utils", "std"]
 smt_hashmaps = ["dep:hashbrown"]
 internal = []
@@ -65,6 +65,7 @@ std = [
 blake3 = { version = "1.6", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
 hashbrown = { version = "0.15", optional = true, features = ["serde"] }
+heed = { version = "0.22.0" }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.9", default-features = false }

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -48,6 +48,7 @@ harness = false
 concurrent = ["dep:rayon", "hashbrown?/rayon"]
 default = ["std", "concurrent", "serde"]
 executable = ["dep:clap", "dep:rand-utils", "std"]
+rocksdb = ["concurrent", "dep:rocksdb"]
 smt_hashmaps = ["dep:hashbrown"]
 internal = []
 serde = ["dep:serde", "serde?/alloc", "winter-math/serde"]
@@ -64,7 +65,7 @@ std = [
 [dependencies]
 blake3 = { version = "1.6", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
-flume = { version = "0.11.1" }
+flume = { version = "0.11"}
 hashbrown = { version = "0.15", optional = true, features = ["serde"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
@@ -72,7 +73,7 @@ rand = { version = "0.9", default-features = false }
 rand_core = { version = "0.9", default-features = false }
 rand-utils = { version = "0.12", package = "winter-rand-utils", optional = true }
 rayon = { version = "1.10", optional = true }
-rocksdb = { version = "0.23.0" }
+rocksdb = { version = "0.23", optional = true, default-features = false, features = ["lz4"] }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 sha3 = { version = "0.10", default-features = false }
 thiserror = { version = "2.0", default-features = false }
@@ -89,6 +90,7 @@ proptest = { version = "1.6", default-features = false, features = ["alloc"]}
 rand_chacha = { version = "0.9", default-features = false }
 rand-utils = { version = "0.12", package = "winter-rand-utils" }
 seq-macro = { version = "0.3" }
+tempfile = { version = "3.20" }
 
 [build-dependencies]
 cc = { version = "1.2", optional = true, features = ["parallel"] }
@@ -97,3 +99,8 @@ glob = "0.3"
 [lints.rust]
 # Suppress warnings about `cfg(fuzzing)`, which is automatically set when using `cargo-fuzz`.
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
+
+[[test]]
+name = "rocksdb_large_smt"
+required-features = ["concurrent", "rocksdb", "internal"]

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -64,6 +64,7 @@ std = [
 [dependencies]
 blake3 = { version = "1.6", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
+flume = { version = "0.11.1" }
 hashbrown = { version = "0.15", optional = true, features = ["serde"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -1,4 +1,6 @@
 use std::time::Instant;
+use std::path::Path;
+use std::fs;
 
 use clap::Parser;
 use miden_crypto::{
@@ -54,7 +56,14 @@ pub fn benchmark_smt() {
 pub fn construction(entries: Vec<(RpoDigest, Word)>, size: usize) -> Result<LargeSmt, MerkleError> {
     println!("Running a construction benchmark:");
     let now = Instant::now();
-    let tree = LargeSmt::with_entries(entries)?;
+    let path = Path::new("bench_large_smt");
+    // delete the folder if it exists
+    if path.exists() {
+        std::fs::remove_dir_all(path).unwrap();
+    }
+    fs::create_dir_all(path).expect("Failed to create database directory");
+
+    let tree = LargeSmt::with_entries(path, entries)?;
     let elapsed = now.elapsed().as_secs_f32();
     println!("Constructed an SMT with {size} key-value pairs in {elapsed:.1} seconds");
     println!("Number of leaf nodes: {}\n", tree.num_leaves());

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use miden_crypto::{
     EMPTY_WORD, Felt, ONE, Word,
     hash::rpo::{Rpo256, RpoDigest},
-    merkle::{MerkleError, Smt},
+    merkle::{LargeSmt, MerkleError, Smt},
 };
 use rand::{Rng, prelude::IteratorRandom, rng};
 use rand_utils::rand_value;
@@ -43,27 +43,27 @@ pub fn benchmark_smt() {
         entries.push((key, value));
     }
 
-    let mut tree = construction(entries.clone(), tree_size).unwrap();
+    let tree = construction(entries.clone(), tree_size).unwrap();
     insertion(&mut tree.clone(), insertions).unwrap();
-    batched_insertion(&mut tree.clone(), insertions).unwrap();
-    batched_update(&mut tree.clone(), entries, updates).unwrap();
-    proof_generation(&mut tree).unwrap();
+    //batched_insertion(&mut tree.clone(), insertions).unwrap();
+    //batched_update(&mut tree.clone(), entries, updates).unwrap();
+    //proof_generation(&mut tree).unwrap();
 }
 
 /// Runs the construction benchmark for [`Smt`], returning the constructed tree.
-pub fn construction(entries: Vec<(RpoDigest, Word)>, size: usize) -> Result<Smt, MerkleError> {
+pub fn construction(entries: Vec<(RpoDigest, Word)>, size: usize) -> Result<LargeSmt, MerkleError> {
     println!("Running a construction benchmark:");
     let now = Instant::now();
-    let tree = Smt::with_entries(entries)?;
+    let tree = LargeSmt::with_entries(entries)?;
     let elapsed = now.elapsed().as_secs_f32();
     println!("Constructed an SMT with {size} key-value pairs in {elapsed:.1} seconds");
-    println!("Number of leaf nodes: {}\n", tree.leaves().count());
+    println!("Number of leaf nodes: {}\n", tree.num_leaves());
 
     Ok(tree)
 }
 
 /// Runs the insertion benchmark for the [`Smt`].
-pub fn insertion(tree: &mut Smt, insertions: usize) -> Result<(), MerkleError> {
+pub fn insertion(tree: &mut LargeSmt, insertions: usize) -> Result<(), MerkleError> {
     println!("Running an insertion benchmark:");
 
     let size = tree.num_leaves();
@@ -88,7 +88,7 @@ pub fn insertion(tree: &mut Smt, insertions: usize) -> Result<(), MerkleError> {
     Ok(())
 }
 
-pub fn batched_insertion(tree: &mut Smt, insertions: usize) -> Result<(), MerkleError> {
+pub fn batched_insertion(tree: &mut LargeSmt, insertions: usize) -> Result<(), MerkleError> {
     println!("Running a batched insertion benchmark:");
 
     let size = tree.num_leaves();

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use miden_crypto::{
     EMPTY_WORD, Felt, ONE, Word,
     hash::rpo::{Rpo256, RpoDigest},
-    merkle::{LargeSmt, MerkleError, Smt},
+    merkle::{LargeSmt, MerkleError},
 };
 use rand::{Rng, prelude::IteratorRandom, rng};
 use rand_utils::rand_value;
@@ -47,8 +47,8 @@ pub fn benchmark_smt() {
 
     let tree = construction(entries.clone(), tree_size).unwrap();
     insertion(&mut tree.clone(), insertions).unwrap();
-    //batched_insertion(&mut tree.clone(), insertions).unwrap();
-    //batched_update(&mut tree.clone(), entries, updates).unwrap();
+    batched_insertion(&mut tree.clone(), insertions).unwrap();
+    batched_update(&mut tree.clone(), entries, updates).unwrap();
     //proof_generation(&mut tree).unwrap();
 }
 
@@ -141,7 +141,7 @@ pub fn batched_insertion(tree: &mut LargeSmt, insertions: usize) -> Result<(), M
 }
 
 pub fn batched_update(
-    tree: &mut Smt,
+    tree: &mut LargeSmt,
     entries: Vec<(RpoDigest, Word)>,
     updates: usize,
 ) -> Result<(), MerkleError> {
@@ -200,7 +200,7 @@ pub fn batched_update(
 }
 
 /// Runs the proof generation benchmark for the [`Smt`].
-pub fn proof_generation(tree: &mut Smt) -> Result<(), MerkleError> {
+pub fn proof_generation(tree: &mut LargeSmt) -> Result<(), MerkleError> {
     const NUM_PROOFS: usize = 100;
 
     println!("Running a proof generation benchmark:");

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -1,6 +1,4 @@
-use std::time::Instant;
-use std::path::Path;
-use std::fs;
+use std::{fs, path::Path, time::Instant};
 
 use clap::Parser;
 use miden_crypto::{
@@ -49,7 +47,7 @@ pub fn benchmark_smt() {
     insertion(&mut tree.clone(), insertions).unwrap();
     batched_insertion(&mut tree.clone(), insertions).unwrap();
     batched_update(&mut tree.clone(), entries, updates).unwrap();
-    //proof_generation(&mut tree).unwrap();
+    proof_generation(&mut tree.clone()).unwrap();
 }
 
 /// Runs the construction benchmark for [`Smt`], returning the constructed tree.

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -16,10 +16,10 @@ pub struct BenchmarkCmd {
     #[clap(short = 's', long = "size", default_value = "1000000")]
     size: usize,
     /// Number of insertions
-    #[clap(short = 'i', long = "insertions", default_value = "1000")]
+    #[clap(short = 'i', long = "insertions", default_value = "10000")]
     insertions: usize,
     /// Number of updates
-    #[clap(short = 'u', long = "updates", default_value = "1000")]
+    #[clap(short = 'u', long = "updates", default_value = "10000")]
     updates: usize,
 }
 

--- a/miden-crypto/src/main.rs
+++ b/miden-crypto/src/main.rs
@@ -4,7 +4,8 @@ use clap::Parser;
 #[cfg(not(feature = "rocksdb"))]
 use miden_crypto::merkle::MemoryStorage;
 #[cfg(feature = "rocksdb")]
-use miden_crypto::merkle::RocksDbStorage;
+use miden_crypto::merkle::{RocksDbConfig, RocksDbStorage};
+
 use miden_crypto::{
     EMPTY_WORD, Felt, ONE, Word,
     hash::rpo::{Rpo256, RpoDigest},
@@ -32,11 +33,14 @@ pub struct BenchmarkCmd {
     #[clap(short = 'u', long = "updates", default_value = "10000")]
     updates: usize,
     /// Path for the benchmark database
-    #[clap(short = 'p', long = "path")]
+    #[clap(short = 'p', long = "path", default_value = "/mnt/rocksdb/benchmark_db")]
     storage_path: Option<PathBuf>,
     /// Open existing database and skip construction
     #[clap(short = 'o', long = "open", default_value = "false")]
     open: bool,
+    /// Number of batch operations
+    #[clap(short = 'b', long = "batches", default_value = "1")]
+    batches: usize,
 }
 
 fn main() {
@@ -51,6 +55,7 @@ pub fn benchmark_smt() {
     let insertions = args.insertions;
     let updates = args.updates;
     let storage_path = args.storage_path;
+    let batches = args.batches;
 
     if cfg!(feature = "rocksdb") {
         println!("Running benchmark with rocksdb storage");
@@ -72,8 +77,10 @@ pub fn benchmark_smt() {
         construction(entries.clone(), tree_size, storage_path).unwrap()
     };
     insertion(&mut tree, insertions).unwrap();
-    batched_insertion(&mut tree, insertions).unwrap();
-    batched_update(&mut tree, entries.clone(), updates).unwrap();
+    for _ in 0..batches {
+        batched_insertion(&mut tree, insertions).unwrap();
+        batched_update(&mut tree, entries.clone(), updates).unwrap();
+    }
     proof_generation(&mut tree).unwrap();
 }
 
@@ -276,8 +283,7 @@ fn get_storage(database_path: Option<PathBuf>, open: bool) -> Storage {
         }
         std::fs::create_dir_all(path.clone()).expect("Failed to create database directory");
     }
-    let storage = Storage::open(&path).expect("Failed to open database");
-    storage
+    Storage::open(RocksDbConfig::new(path).with_cache_size(1 << 30).with_max_open_files(1024)).expect("Failed to open database")
 }
 
 #[cfg(not(feature = "rocksdb"))]

--- a/miden-crypto/src/merkle/mod.rs
+++ b/miden-crypto/src/merkle/mod.rs
@@ -22,8 +22,8 @@ pub use path::{MerklePath, RootPath, ValuePath};
 
 mod smt;
 pub use smt::{
-    InnerNode, LeafIndex, MutationSet, NodeMutation, PartialSmt, SMT_DEPTH, SMT_MAX_DEPTH,
-    SMT_MIN_DEPTH, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError,
+    InnerNode, LargeSmt, LeafIndex, MutationSet, NodeMutation, PartialSmt, SMT_DEPTH,
+    SMT_MAX_DEPTH, SMT_MIN_DEPTH, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError,
 };
 #[cfg(feature = "internal")]
 pub use smt::{SubtreeLeaf, build_subtree_for_bench};

--- a/miden-crypto/src/merkle/mod.rs
+++ b/miden-crypto/src/merkle/mod.rs
@@ -22,7 +22,7 @@ pub use path::{MerklePath, RootPath, ValuePath};
 
 mod smt;
 pub use smt::{
-    InnerNode, LargeSmt, LeafIndex, MutationSet, NodeMutation, PartialSmt, SMT_DEPTH,
+    InnerNode, LargeSmt, LeafIndex, MemoryStorage, MutationSet, NodeMutation, PartialSmt, RocksDbStorage, SMT_DEPTH,
     SMT_MAX_DEPTH, SMT_MIN_DEPTH, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError,
 };
 #[cfg(feature = "internal")]

--- a/miden-crypto/src/merkle/mod.rs
+++ b/miden-crypto/src/merkle/mod.rs
@@ -22,7 +22,7 @@ pub use path::{MerklePath, RootPath, ValuePath};
 
 mod smt;
 #[cfg(feature = "rocksdb")]
-pub use smt::RocksDbStorage;
+pub use smt::{RocksDbConfig, RocksDbStorage};
 #[cfg(feature = "internal")]
 pub use smt::test_details;
 pub use smt::{

--- a/miden-crypto/src/merkle/mod.rs
+++ b/miden-crypto/src/merkle/mod.rs
@@ -21,10 +21,16 @@ mod path;
 pub use path::{MerklePath, RootPath, ValuePath};
 
 mod smt;
+#[cfg(feature = "rocksdb")]
+pub use smt::RocksDbStorage;
+#[cfg(feature = "internal")]
+pub use smt::test_details;
 pub use smt::{
-    InnerNode, LargeSmt, LeafIndex, MemoryStorage, MutationSet, NodeMutation, PartialSmt, RocksDbStorage, SMT_DEPTH,
-    SMT_MAX_DEPTH, SMT_MIN_DEPTH, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError,
+    InnerNode, LeafIndex, MutationSet, NodeMutation, PartialSmt, SMT_DEPTH, SMT_MAX_DEPTH,
+    SMT_MIN_DEPTH, SimpleSmt, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError,
 };
+#[cfg(feature = "concurrent")]
+pub use smt::{LargeSmt, MemoryStorage};
 #[cfg(feature = "internal")]
 pub use smt::{SubtreeLeaf, build_subtree_for_bench};
 

--- a/miden-crypto/src/merkle/smt/full/concurrent/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/mod.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::merkle::smt::{NodeMutation, NodeMutations, UnorderedMap};
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 pub(crate) type MutatedSubtreeLeaves = Vec<Vec<SubtreeLeaf>>;
 
@@ -326,7 +326,7 @@ impl Smt {
 pub(crate) const SUBTREE_DEPTH: u8 = 8;
 
 /// A depth-8 subtree contains 256 "columns" that can possibly be occupied.
-const COLS_PER_SUBTREE: u64 = u64::pow(2, SUBTREE_DEPTH as u32);
+pub(crate) const COLS_PER_SUBTREE: u64 = u64::pow(2, SUBTREE_DEPTH as u32);
 
 /// Helper struct for organizing the data we care about when computing Merkle subtrees.
 ///

--- a/miden-crypto/src/merkle/smt/full/concurrent/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/mod.rs
@@ -13,7 +13,7 @@ use crate::merkle::smt::{NodeMutation, NodeMutations, UnorderedMap};
 #[cfg(test)]
 mod tests;
 
-type MutatedSubtreeLeaves = Vec<Vec<SubtreeLeaf>>;
+pub(crate) type MutatedSubtreeLeaves = Vec<Vec<SubtreeLeaf>>;
 
 // CONCURRENT IMPLEMENTATIONS
 // ================================================================================================
@@ -440,7 +440,7 @@ impl Iterator for SubtreeLeavesIter<'_> {
 ///
 /// # Panics
 /// This function will panic in debug mode if the input `pairs` are not sorted by column index.
-fn process_sorted_pairs_to_leaves<F>(
+pub(crate) fn process_sorted_pairs_to_leaves<F>(
     pairs: Vec<(RpoDigest, Word)>,
     mut process_leaf: F,
 ) -> Result<PairComputations<u64, SmtLeaf>, MerkleError>
@@ -644,7 +644,7 @@ pub(crate) fn build_subtree(
 ///   or copied from the `parent_node`.
 ///
 /// Returns the `InnerNode` containing the hashes of the sibling pair.
-fn fetch_sibling_pair(
+pub(crate) fn fetch_sibling_pair(
     iter: &mut core::iter::Peekable<alloc::vec::Drain<SubtreeLeaf>>,
     first_leaf: SubtreeLeaf,
     parent_node: InnerNode,

--- a/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
@@ -101,7 +101,7 @@ fn test_sorted_pairs_to_leaves() {
 }
 
 // Helper for the below tests.
-fn generate_entries(pair_count: u64) -> Vec<(RpoDigest, Word)> {
+pub(crate) fn generate_entries(pair_count: u64) -> Vec<(RpoDigest, Word)> {
     (0..pair_count)
         .map(|i| {
             let leaf_index = ((i as f64 / pair_count as f64) * (pair_count as f64)) as u64;
@@ -112,7 +112,10 @@ fn generate_entries(pair_count: u64) -> Vec<(RpoDigest, Word)> {
         .collect()
 }
 
-fn generate_updates(entries: Vec<(RpoDigest, Word)>, updates: usize) -> Vec<(RpoDigest, Word)> {
+pub(crate) fn generate_updates(
+    entries: Vec<(RpoDigest, Word)>,
+    updates: usize,
+) -> Vec<(RpoDigest, Word)> {
     const REMOVAL_PROBABILITY: f64 = 0.2;
     let mut rng = rng();
     // Assertion to ensure input keys are unique

--- a/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
@@ -250,8 +250,7 @@ fn test_singlethreaded_subtrees() {
                     let control_node = control.get_inner_node(index);
                     assert_eq!(
                         test_node, &control_node,
-                        "depth {} subtree {}: test node does not match control at index {:?}",
-                        current_depth, i, index,
+                        "depth {current_depth} subtree {i}: test node does not match control at index {index:?}"
                     );
                 }
                 (nodes, subtree_root)
@@ -332,8 +331,7 @@ fn test_multithreaded_subtrees() {
                     let control_node = control.get_inner_node(index);
                     assert_eq!(
                         test_node, &control_node,
-                        "depth {} subtree {}: test node does not match control at index {:?}",
-                        current_depth, i, index,
+                        "depth {current_depth} subtree {i}: test node does not match control at index {index:?}",
                     );
                 }
                 (nodes, subtree_root)
@@ -431,8 +429,7 @@ fn test_singlethreaded_subtree_mutations() {
                     let control_mutation = control.node_mutations().get(&index).unwrap();
                     assert_eq!(
                         control_mutation, mutation,
-                        "depth {} subtree {}: mutation does not match control at index {:?}",
-                        current_depth, i, index,
+                        "depth {current_depth} subtree {i}: mutation does not match control at index {index:?}",
                     );
                 }
                 (mutations_per_subtree, subtree_root)

--- a/miden-crypto/src/merkle/smt/full/large/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/large/mod.rs
@@ -109,7 +109,7 @@ impl LargeSmt {
     /// # Errors
     /// Returns an error if the provided entries contain multiple values for the same key.
     pub fn with_entries(
-        entries: impl IntoIterator<Item = (RpoDigest, Word)>,
+        path: &Path, entries: impl IntoIterator<Item = (RpoDigest, Word)>,
     ) -> Result<Self, MerkleError> {
         let entries: Vec<(RpoDigest, Word)> = entries.into_iter().collect();
 
@@ -117,7 +117,7 @@ impl LargeSmt {
             return Ok(Self::default());
         }
 
-        let mut tree = LargeSmt::default();
+        let mut tree = LargeSmt::new(path);
         tree.build_subtrees(entries)?;
         Ok(tree)
     }

--- a/miden-crypto/src/merkle/smt/full/large/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/large/mod.rs
@@ -26,13 +26,18 @@ use subtree::Subtree;
 
 mod storage;
 #[cfg(feature = "rocksdb")]
-pub use storage::RocksDbStorage;
+pub use storage::{RocksDbConfig, RocksDbStorage};
 pub use storage::{MemoryStorage, SmtStorage, StorageUpdates};
 
 // CONSTANTS
 // ================================================================================================
 
+/// Number of levels of the tree that are stored in memory
 const IN_MEMORY_DEPTH: u8 = 24;
+
+/// Number of nodes that are stored in memory
+const NUM_IN_MEMORY_LEAVES: usize = (1 << IN_MEMORY_DEPTH) - 1;
+
 /// Number of subtree levels below in-memory depth (24-64 in steps of 8)
 const NUM_SUBTREE_LEVELS: usize = 5;
 
@@ -100,57 +105,63 @@ impl<S: SmtStorage> LargeSmt<S> {
             .get_root()
             .expect("Failed to get root")
             .unwrap_or(*EmptySubtreeRoots::entry(SMT_DEPTH, 0));
-
-        let leaf_count = storage.leaf_count().expect("Failed to get leaf count");
-
+        
+        let is_empty = !storage.has_leaves().expect("Failed to check if storage has leaves");
+    
         // Initialize in-memory cache structure
-        let num_in_memory_nodes = (1 << IN_MEMORY_DEPTH) - 1;
-        let mut in_memory_nodes: Vec<Option<Box<InnerNode>>> = vec![None; num_in_memory_nodes];
+        let mut in_memory_nodes: Vec<Option<Box<InnerNode>>> = vec![None; NUM_IN_MEMORY_LEAVES];
 
-        // If there are leaves, materialize the in-memory nodes
-        if leaf_count > 0 {
-            let subtree_roots = storage.get_depth24().expect("Failed to get subtree roots");
-            // convert subtree roots to SubtreeLeaf
-            let mut leaf_subtrees: Vec<SubtreeLeaf> = subtree_roots
-                .into_iter()
-                .map(|(index, hash)| SubtreeLeaf { col: index, hash })
-                .collect();
-            leaf_subtrees.sort_by_key(|leaf| leaf.col);
+        // No leaves, return empty tree
+        if is_empty {
+            return Ok(Self {
+                root,
+                storage: Arc::new(storage),
+                in_memory_nodes,
+            });
+        }
 
-            let mut subtree_leaves: Vec<Vec<SubtreeLeaf>> =
-                SubtreeLeavesIter::from_leaves(&mut leaf_subtrees).collect();
-            for current_depth in
-                (SUBTREE_DEPTH..=IN_MEMORY_DEPTH).step_by(SUBTREE_DEPTH as usize).rev()
-            {
-                let (nodes, mut subtree_roots): (Vec<UnorderedMap<_, _>>, Vec<SubtreeLeaf>) =
-                    subtree_leaves
-                        .into_par_iter()
-                        .map(|subtree| {
-                            debug_assert!(subtree.is_sorted());
-                            debug_assert!(!subtree.is_empty());
-                            let (nodes, subtree_root) =
-                                build_subtree(subtree, SMT_DEPTH, current_depth);
-                            (nodes, subtree_root)
-                        })
-                        .unzip();
-                subtree_leaves = SubtreeLeavesIter::from_leaves(&mut subtree_roots).collect();
-                debug_assert!(!subtree_leaves.is_empty());
+        let subtree_roots = storage.get_depth24().expect("Failed to get subtree roots");
+        // convert subtree roots to SubtreeLeaf
+        let mut leaf_subtrees: Vec<SubtreeLeaf> = subtree_roots
+            .into_iter()
+            .map(|(index, hash)| SubtreeLeaf { col: index, hash })
+            .collect();
+        leaf_subtrees.sort_by_key(|leaf| leaf.col);
 
-                for subtree_nodes in nodes {
-                    for (index, node) in subtree_nodes {
-                        let memory_index = to_memory_index(&index);
-                        in_memory_nodes[memory_index] = Some(Box::new(node));
-                    }
+        let mut subtree_leaves: Vec<Vec<SubtreeLeaf>> =
+            SubtreeLeavesIter::from_leaves(&mut leaf_subtrees).collect();
+        for current_depth in
+            (SUBTREE_DEPTH..=IN_MEMORY_DEPTH).step_by(SUBTREE_DEPTH as usize).rev()
+        {
+            let (nodes, mut subtree_roots): (Vec<UnorderedMap<_, _>>, Vec<SubtreeLeaf>) =
+                subtree_leaves
+                    .into_par_iter()
+                    .map(|subtree| {
+                        debug_assert!(subtree.is_sorted());
+                        debug_assert!(!subtree.is_empty());
+                        let (nodes, subtree_root) =
+                            build_subtree(subtree, SMT_DEPTH, current_depth);
+                        (nodes, subtree_root)
+                    })
+                    .unzip();
+            subtree_leaves = SubtreeLeavesIter::from_leaves(&mut subtree_roots).collect();
+            debug_assert!(!subtree_leaves.is_empty());
+
+            for subtree_nodes in nodes {
+                for (index, node) in subtree_nodes {
+                    let memory_index = to_memory_index(&index);
+                    in_memory_nodes[memory_index] = Some(Box::new(node));
                 }
             }
-
-            // Check that the calculated root matches the root in storage
-            assert_eq!(
-                in_memory_nodes[0].as_ref().unwrap().hash(),
-                root,
-                "Tree reconstruction failed - root mismatch"
-            );
         }
+
+        // Check that the calculated root matches the root in storage
+        assert_eq!(
+            in_memory_nodes[0].as_ref().unwrap().hash(),
+            root,
+            "Tree reconstruction failed - root mismatch"
+        );
+        
         Ok(Self {
             root,
             storage: Arc::new(storage),
@@ -173,7 +184,7 @@ impl<S: SmtStorage> LargeSmt<S> {
     ) -> Result<Self, MerkleError> {
         let entries: Vec<(RpoDigest, Word)> = entries.into_iter().collect();
 
-        if storage.leaf_count().expect("Failed to get leaf count") > 0 {
+        if storage.has_leaves().expect("Failed to check if storage has leaves") {
             panic!("Cannot create SMT with non-empty storage");
         }
         let mut tree = LargeSmt::new(storage).expect("Failed to create SMT");
@@ -182,19 +193,6 @@ impl<S: SmtStorage> LargeSmt<S> {
         }
         tree.build_subtrees(entries)?;
         Ok(tree)
-    }
-
-    /// Returns a new [`Smt`] instantiated from already computed leaves and nodes.
-    ///
-    /// This function performs minimal consistency checking. It is the caller's responsibility to
-    /// ensure the passed arguments are correct and consistent with each other.
-    ///
-    /// # Panics
-    /// With debug assertions on, this function panics if `root` does not match the root node in
-    /// `inner_nodes`.
-    pub fn from_raw_parts(inner_nodes: InnerNodes, leaves: Leaves, root: RpoDigest) -> Self {
-        // Our particular implementation of `from_raw_parts()` never returns `Err`.
-        <Self as SparseMerkleTree<SMT_DEPTH>>::from_raw_parts(inner_nodes, leaves, root).unwrap()
     }
 
     // PUBLIC ACCESSORS
@@ -444,7 +442,7 @@ impl<S: SmtStorage> LargeSmt<S> {
         }
 
         // Sort mutations
-        let mut sorted_mutations: Vec<_> = node_mutations.into_iter().collect();
+        let mut sorted_mutations: Vec<_> = Vec::from_iter(node_mutations);
         sorted_mutations.par_sort_unstable_by_key(|(index, _)| Subtree::find_subtree_root(*index));
 
         // Collect all unique subtree root indexes needed
@@ -528,33 +526,41 @@ impl<S: SmtStorage> LargeSmt<S> {
 
         for (key, value) in new_pairs {
             let idx = Self::key_to_leaf_index(&key).value();
-            let entry: &mut Option<SmtLeaf> = leaf_map.entry(idx).or_insert(None);
-
-            match (entry.as_mut(), value == Self::EMPTY_VALUE) {
-                // Delete
-                (Some(leaf), true) => {
+            // Get leaf
+            let entry = leaf_map.entry(idx).or_insert(None);
+        
+            // New values is empty, handle deletion
+            if value == Self::EMPTY_VALUE {
+                if let Some(leaf) = entry {
+                    // Leaf exists, handle deletion
                     if leaf.remove(key).1 {
+                        // Key had previous value, decrement entry count
                         entry_count_delta -= 1;
                         if leaf.is_empty() {
+                            // Leaf is now empty, remove it and decrement leaf count
                             *entry = None;
                             leaf_count_delta -= 1;
                         }
                     }
-                },
-                // Update
-                (Some(leaf), false) => {
-                    if leaf.insert(key, value).is_none() {
-                        entry_count_delta += 1;
+                }
+            } else {
+                // New value is not empty, handle update or create
+                match entry {
+                    Some(leaf) => {
+                        // Leaf exists, handle update
+                        if leaf.insert(key, value).is_none() {
+                            // Key had no previous value, increment entry count
+                            entry_count_delta += 1;
+                        }
                     }
-                },
-                // Create
-                (None, false) => {
-                    *entry = Some(SmtLeaf::Single((key, value)));
-                    leaf_count_delta += 1;
-                    entry_count_delta += 1;
-                },
-                // Nothing to do
-                _ => {},
+                    None => {
+                        // Leaf does not exist, create it
+                        *entry = Some(SmtLeaf::Single((key, value)));
+                        // Increment both entry and leaf count
+                        entry_count_delta += 1;
+                        leaf_count_delta += 1;
+                    }
+                }
             }
         }
 
@@ -618,7 +624,7 @@ impl<S: SmtStorage> LargeSmt<S> {
 
         let mut reverse_pairs = UnorderedMap::new();
         for (key, value) in new_pairs {
-            if let Some(old_value) = self.insert_value(key.clone(), value) {
+            if let Some(old_value) = self.insert_value(key, value) {
                 reverse_pairs.insert(key, old_value);
             } else {
                 reverse_pairs.insert(key, Self::EMPTY_VALUE);
@@ -697,7 +703,6 @@ impl<S: SmtStorage> LargeSmt<S> {
                     let subtree_root_index =
                         NodeIndex::new(bottom_depth - SUBTREE_DEPTH, subtree_root.col).unwrap();
                     let mut subtree = Subtree::new(subtree_root_index);
-                    // TODO: make this more efficient?
                     for (index, node) in nodes {
                         subtree.insert_inner_node(index, node);
                     }
@@ -823,13 +828,14 @@ impl<S: SmtStorage> LargeSmt<S> {
                 // This constructs a valid index because next_depth will never exceed the depth of
                 // the tree.
                 let parent_index = NodeIndex::new_unchecked(next_depth, first_leaf.col).parent();
-                let parent_node = match subtree {
-                    Some(ref subtree) => {
-                        subtree.get_inner_node(parent_index).unwrap_or_else(|| {
-                            EmptySubtreeRoots::get_inner_node(SMT_DEPTH, parent_index.depth())
-                        })
-                    },
-                    None => self.get_inner_node(parent_index),
+                let parent_node = if let Some(ref sub) = subtree {
+                    sub.get_inner_node(parent_index).unwrap_or_else(|| {
+                        EmptySubtreeRoots::get_inner_node(SMT_DEPTH, parent_index.depth())
+                    })
+                } else if subtree_root_depth >= IN_MEMORY_DEPTH {
+                    EmptySubtreeRoots::get_inner_node(SMT_DEPTH, parent_index.depth())
+                } else {
+                    self.get_inner_node(parent_index)
                 };
                 let combined_node = fetch_sibling_pair(&mut iter, first_leaf, parent_node);
                 let combined_hash = combined_node.hash();

--- a/miden-crypto/src/merkle/smt/full/large/storage/memory.rs
+++ b/miden-crypto/src/merkle/smt/full/large/storage/memory.rs
@@ -1,28 +1,54 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use std::sync::RwLock;
-use crate::merkle::smt::UnorderedMap;
-use crate::merkle::{EmptySubtreeRoots, InnerNode, NodeIndex, RpoDigest, SmtLeaf};
-use crate::merkle::smt::full::large::{subtree::Subtree, IN_MEMORY_DEPTH, SMT_DEPTH};
 
 use super::{SmtStorage, StorageError, StorageUpdates};
+use crate::{
+    EMPTY_WORD, Word,
+    merkle::{
+        EmptySubtreeRoots, InnerNode, NodeIndex, RpoDigest, SmtLeaf,
+        smt::{
+            UnorderedMap,
+            full::large::{IN_MEMORY_DEPTH, SMT_DEPTH, subtree::Subtree},
+        },
+    },
+};
 
+/// In-memory storage for a Sparse Merkle Tree (SMT), implementing the `SmtStorage` trait.
+///
+/// This structure stores the SMT's root hash, leaf nodes, and subtrees directly in memory.
+/// Access to these components is synchronized using `std::sync::RwLock` for thread safety.
+///
+/// It is primarily intended for scenarios where data persistence to disk is not a
+/// primary concern. Common use cases include:
+/// - Testing environments.
+/// - Managing SMT instances with a limited operational lifecycle.
+/// - Situations where a higher-level application architecture handles its own data persistence
+///   strategy.
 #[derive(Debug)]
 pub struct MemoryStorage {
     pub root: RwLock<RpoDigest>,
     pub leaves: RwLock<UnorderedMap<u64, SmtLeaf>>,
     pub subtrees: RwLock<UnorderedMap<NodeIndex, Subtree>>,
-    pub upper_nodes: RwLock<UnorderedMap<NodeIndex, InnerNode>>,
 }
 
 impl MemoryStorage {
+    /// Creates a new, empty in-memory storage for a Sparse Merkle Tree.
+    ///
+    /// Initializes the root to the empty SMT root for the defined SMT_DEPTH,
+    /// and empty maps for leaves and subtrees.
     pub fn new() -> Self {
         let root_val = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
         Self {
             root: RwLock::new(root_val),
             leaves: RwLock::new(UnorderedMap::new()),
             subtrees: RwLock::new(UnorderedMap::new()),
-            upper_nodes: RwLock::new(UnorderedMap::new()),
         }
+    }
+}
+
+impl Default for MemoryStorage {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -30,188 +56,405 @@ impl Clone for MemoryStorage {
     fn clone(&self) -> Self {
         MemoryStorage {
             root: RwLock::new(*self.root.read().expect("Failed to read lock for root in clone")),
-            leaves: RwLock::new(self.leaves.read().expect("Failed to read lock for leaves in clone").clone()),
-            subtrees: RwLock::new(self.subtrees.read().expect("Failed to read lock for subtrees in clone").clone()),
-            upper_nodes: RwLock::new(self.upper_nodes.read().expect("Failed to read lock for upper_nodes in clone").clone()),
+            leaves: RwLock::new(
+                self.leaves.read().expect("Failed to read lock for leaves in clone").clone(),
+            ),
+            subtrees: RwLock::new(
+                self.subtrees.read().expect("Failed to read lock for subtrees in clone").clone(),
+            ),
         }
     }
 }
 
 impl SmtStorage for MemoryStorage {
-
+    /// Retrieves the current root hash of the Sparse Merkle Tree.
     fn get_root(&self) -> Result<Option<RpoDigest>, StorageError> {
-        Ok(Some(*self.root.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for root".into()))?))
+        Ok(Some(*self.root.read().map_err(|_| {
+            StorageError::BackendError("Failed to acquire read lock for root".into())
+        })?))
+    }
+
+    /// Sets the root hash of the Sparse Merkle Tree.
+    fn set_root(&self, root: RpoDigest) -> Result<(), StorageError> {
+        *self.root.write().map_err(|_| {
+            StorageError::BackendError("Failed to acquire write lock for root".into())
+        })? = root;
+        Ok(())
     }
 
     /// Gets the total number of non-empty leaves currently stored.
-    fn get_leaf_count(&self) -> Result<usize, StorageError> {
-        Ok(self.leaves.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for leaves count".into()))?.len())
-    }   
+    fn leaf_count(&self) -> Result<usize, StorageError> {
+        Ok(self
+            .leaves
+            .read()
+            .map_err(|_| {
+                StorageError::BackendError("Failed to acquire read lock for leaves count".into())
+            })?
+            .len())
+    }
 
     /// Gets the total number of key-value entries currently stored.
-    fn get_entry_count(&self) -> Result<usize, StorageError> {
-        Ok(self.leaves.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for entry count".into()))?.len())
+    fn entry_count(&self) -> Result<usize, StorageError> {
+        Ok(self
+            .leaves
+            .read()
+            .map_err(|_| {
+                StorageError::BackendError("Failed to acquire read lock for entry count".into())
+            })?
+            .iter()
+            .map(|(_, leaf)| leaf.num_entries() as usize)
+            .sum())
+    }
+
+    /// Inserts a key-value pair into the leaf at the given index.
+    ///
+    /// - If the leaf at `index` does not exist, a new `SmtLeaf::Single` is created.
+    /// - If the leaf exists, the key-value pair is inserted into it.
+    /// - Returns the previous value associated with the key, if any.
+    ///
+    /// # Errors
+    /// Returns `StorageError::BackendError` if the write lock cannot be acquired.
+    ///
+    /// # Panics
+    /// Panics in debug builds if `value` is `EMPTY_WORD`.
+    fn insert_value(
+        &self,
+        index: u64,
+        key: RpoDigest,
+        value: Word,
+    ) -> Result<Option<Word>, StorageError> {
+        debug_assert_ne!(value, EMPTY_WORD);
+        let mut leaves_guard = self.leaves.write().map_err(|_| {
+            StorageError::BackendError("Failed to acquire write lock for insert_value".into())
+        })?;
+
+        match leaves_guard.get_mut(&index) {
+            Some(leaf) => Ok(leaf.insert(key, value)),
+            None => {
+                leaves_guard.insert(index, SmtLeaf::Single((key, value)));
+                Ok(None)
+            },
+        }
+    }
+
+    /// Removes a key-value pair from the leaf at the given `index`.
+    ///
+    /// - If the leaf at `index` exists and the `key` is found within that leaf, the key-value pair
+    ///   is removed, and the old `Word` value is returned in `Ok(Some(Word))`.
+    /// - If the leaf at `index` exists but the `key` is not found within that leaf, `Ok(None)` is
+    ///   returned (as `leaf.get_value(&key)` would be `None`).
+    /// - If the leaf at `index` does not exist, `Ok(None)` is returned, as no value could be
+    ///   removed.
+    ///
+    /// # Errors
+    /// Returns `StorageError::BackendError` if the write lock for leaves cannot be acquired.
+    fn remove_value(&self, index: u64, key: RpoDigest) -> Result<Option<Word>, StorageError> {
+        let mut leaves_guard = self.leaves.write().map_err(|_| {
+            StorageError::BackendError("Failed to acquire write lock for remove_value".into())
+        })?;
+
+        match leaves_guard.get_mut(&index) {
+            Some(leaf) => {
+                let old_value = leaf.get_value(&key);
+                leaf.remove(key);
+                Ok(old_value)
+            },
+            None => {
+                // Leaf at index does not exist, so no value could be removed.
+                Ok(None)
+            },
+        }
     }
 
     /// Retrieves a single leaf node.
     fn get_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError> {
-        Ok(self.leaves.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_leaf".into()))?.get(&index).cloned())
+        Ok(self
+            .leaves
+            .read()
+            .map_err(|_| {
+                StorageError::BackendError("Failed to acquire read lock for get_leaf".into())
+            })?
+            .get(&index)
+            .cloned())
     }
 
-    /// Sets a single leaf node.
-    fn set_leaf(&self, index: u64, leaf: &SmtLeaf) -> Result<Option<SmtLeaf>, StorageError> {
-        Ok(self.leaves.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_leaf".into()))?.insert(index, leaf.clone()))
-    }
-
-    /// Sets multiple leaf nodes.
+    /// Sets multiple leaf nodes in storage.
+    ///
+    /// If a leaf at a given index already exists, it is overwritten.
+    ///
+    /// # Errors
+    /// Returns `StorageError::BackendError` if the write lock for leaves cannot be acquired.
     fn set_leaves(&self, leaves_map: UnorderedMap<u64, SmtLeaf>) -> Result<(), StorageError> {
-        let mut leaves_guard = self.leaves.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_leaves".into()))?;
-        for (index, leaf) in leaves_map {
-            leaves_guard.insert(index, leaf);
-        }
+        let mut leaves_guard = self.leaves.write().map_err(|_| {
+            StorageError::BackendError("Failed to acquire write lock for set_leaves".into())
+        })?;
+        leaves_guard.extend(leaves_map);
         Ok(())
     }
 
     /// Removes a single leaf node.
     fn remove_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError> {
-        Ok(self.leaves.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for remove_leaf".into()))?.remove(&index))
+        Ok(self
+            .leaves
+            .write()
+            .map_err(|_| {
+                StorageError::BackendError("Failed to acquire write lock for remove_leaf".into())
+            })?
+            .remove(&index))
     }
 
     /// Retrieves multiple leaf nodes. Returns Ok(None) for indices not found.
     fn get_leaves(&self, indices: &[u64]) -> Result<Vec<Option<SmtLeaf>>, StorageError> {
-        let leaves_guard = self.leaves.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_leaves".into()))?;
-        let mut res = Vec::with_capacity(indices.len());
-        for &idx in indices {
-            res.push(leaves_guard.get(&idx).cloned());
-        }
-        Ok(res)
+        let leaves_guard = self.leaves.read().map_err(|_| {
+            StorageError::BackendError("Failed to acquire read lock for get_leaves".into())
+        })?;
+        let leaves = indices.iter().map(|idx| leaves_guard.get(idx).cloned()).collect();
+        Ok(leaves)
     }
 
     /// Retrieves a single Subtree (representing deep nodes) by its root NodeIndex.
-    /// Assumes index.depth() > IN_MEMORY_DEPTH. Returns Ok(None) if not found.
+    /// Assumes index.depth() >= IN_MEMORY_DEPTH. Returns Ok(None) if not found.
     fn get_subtree(&self, index: NodeIndex) -> Result<Option<Subtree>, StorageError> {
-        Ok(self.subtrees.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_subtree".into()))?.get(&index).cloned())
+        Ok(self
+            .subtrees
+            .read()
+            .map_err(|_| {
+                StorageError::BackendError("Failed to acquire read lock for get_subtree".into())
+            })?
+            .get(&index)
+            .cloned())
     }
 
     /// Retrieves multiple Subtrees.
-    /// Assumes index.depth() > IN_MEMORY_DEPTH for all indices. Returns Ok(None) for indices not found.
+    /// Assumes index.depth() >= IN_MEMORY_DEPTH for all indices. Returns Ok(None) for indices not
+    /// found.
     fn get_subtrees(&self, indices: &[NodeIndex]) -> Result<Vec<Option<Subtree>>, StorageError> {
-        let subtrees_guard = self.subtrees.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_subtrees".into()))?;
-        let mut res = Vec::with_capacity(indices.len());
-        for &idx in indices {
-            res.push(subtrees_guard.get(&idx).cloned());
-        }
-        Ok(res)
+        let subtrees_guard = self.subtrees.read().map_err(|_| {
+            StorageError::BackendError("Failed to acquire read lock for get_subtrees".into())
+        })?;
+        let subtrees: Vec<_> = indices.iter().map(|idx| subtrees_guard.get(idx).cloned()).collect();
+        Ok(subtrees)
     }
 
     /// Sets a single Subtree (representing deep nodes) by its root NodeIndex.
+    ///
+    /// If a subtree with the same root NodeIndex already exists, it is overwritten.
+    /// Assumes `subtree.root_index().depth() >= IN_MEMORY_DEPTH`.
+    ///
+    /// # Errors
+    /// Returns `StorageError::BackendError` if the write lock for subtrees cannot be acquired.
     fn set_subtree(&self, subtree: &Subtree) -> Result<(), StorageError> {
-        self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_subtree".into()))?.insert(subtree.root_index, subtree.clone());
+        self.subtrees
+            .write()
+            .map_err(|_| {
+                StorageError::BackendError("Failed to acquire write lock for set_subtree".into())
+            })?
+            .insert(subtree.root_index(), subtree.clone());
         Ok(())
     }
 
     /// Sets multiple Subtrees (representing deep nodes) by their root NodeIndex.
+    ///
+    /// If a subtree with a given root NodeIndex already exists, it is overwritten.
+    /// Assumes `subtree.root_index().depth() >= IN_MEMORY_DEPTH` for all subtrees in the vector.
+    ///
+    /// # Errors
+    /// Returns `StorageError::BackendError` if the write lock for subtrees cannot be acquired.
     fn set_subtrees(&self, subtrees_vec: Vec<Subtree>) -> Result<(), StorageError> {
-        let mut subtrees_guard = self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_subtrees".into()))?;
-        for subtree in subtrees_vec {
-            subtrees_guard.insert(subtree.root_index, subtree);
-        }
+        let mut subtrees_guard = self.subtrees.write().map_err(|_| {
+            StorageError::BackendError("Failed to acquire write lock for set_subtrees".into())
+        })?;
+        subtrees_guard
+            .extend(subtrees_vec.into_iter().map(|subtree| (subtree.root_index(), subtree)));
         Ok(())
     }
 
     /// Removes a single Subtree (representing deep nodes) by its root NodeIndex.
     fn remove_subtree(&self, index: NodeIndex) -> Result<(), StorageError> {
-        self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for remove_subtree".into()))?.remove(&index);
-        Ok(())  
-    }
-
-    /// Retrieves a single inner node.
-    fn get_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError> {
-        if index.depth() <= IN_MEMORY_DEPTH {
-            return Ok(self.upper_nodes.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_inner_node (upper)".into()))?.get(&index).cloned());
-        }
-        let subtree_root_index = Subtree::find_subtree_root(index);
-        let subtrees_guard = self.subtrees.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_inner_node (subtrees)".into()))?;
-        match subtrees_guard.get(&subtree_root_index) {
-            Some(subtree) => Ok(subtree.get_inner_node(index)),
-            None => Ok(None),
-        }
-    }
-
-    /// Retrieves multiple upper-level inner nodes by their indices.
-    fn get_upper_nodes(&self, indices: &[NodeIndex]) -> Result<Vec<Option<InnerNode>>, StorageError> {
-        let upper_nodes_guard = self.upper_nodes.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_upper_nodes".into()))?;
-        let mut res = Vec::with_capacity(indices.len());
-        for &idx in indices {
-            if idx.depth() <= IN_MEMORY_DEPTH {
-                res.push(upper_nodes_guard.get(&idx).cloned());
-            } else {
-                return Err(StorageError::OperationNotSupported("get_upper_nodes called with deep node index".into()));
-            }
-        }
-        Ok(res)
-    }
-
-    /// Sets a single inner node.
-    fn set_inner_node(&self, index: NodeIndex, node: InnerNode) -> Result<Option<InnerNode>, StorageError> {
-        if index.depth() <= IN_MEMORY_DEPTH {
-            Ok(self.upper_nodes.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_inner_node (upper)".into()))?.insert(index, node))
-        } else {
-            let subtree_root_index = Subtree::find_subtree_root(index);
-            let mut subtrees_guard = self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_inner_node (subtrees)".into()))?;
-            let mut subtree = subtrees_guard.remove(&subtree_root_index).unwrap_or_else(|| Subtree::new(subtree_root_index));
-            let old_node = subtree.insert_inner_node(index, node);
-            subtrees_guard.insert(subtree_root_index, subtree);
-            Ok(old_node)
-        }
-    }
-
-    /// Removes a single inner node.
-    fn remove_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError> {
-        if index.depth() <= IN_MEMORY_DEPTH {
-            return Ok(self.upper_nodes.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for remove_inner_node (upper)".into()))?.remove(&index));
-        }
-        let subtree_root_index = Subtree::find_subtree_root(index);
-        let mut subtrees_guard = self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for remove_inner_node (subtrees)".into()))?;
-        if let Some(mut subtree) = subtrees_guard.remove(&subtree_root_index) {
-            let old_node = subtree.remove_inner_node(index);
-            if !subtree.is_empty() {
-                subtrees_guard.insert(subtree_root_index, subtree);
-            }
-            Ok(old_node)
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Applies a set of updates atomically.
-    /// This includes updates to leaves, deep subtrees, upper nodes, the root hash,
-    /// and atomically updating persisted leaf/entry counts based on deltas.
-    fn apply_batch(&self, updates: StorageUpdates) -> Result<(), StorageError> {
-        let mut root_guard = self.root.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for root in apply_batch".into()))?;
-        let mut leaves_guard = self.leaves.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for leaves in apply_batch".into()))?;
-        let mut subtrees_guard = self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for subtrees in apply_batch".into()))?;
-        let mut upper_nodes_guard = self.upper_nodes.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for upper_nodes in apply_batch".into()))?;
-
-        for (index, leaf_opt) in updates.leaf_updates {
-            match leaf_opt {    
-                Some(leaf) => { leaves_guard.insert(index, leaf); },
-                None => { leaves_guard.remove(&index); },
-            };
-        }
-        for (index, subtree_opt) in updates.subtree_updates {
-            match subtree_opt {
-                Some(subtree) => { subtrees_guard.insert(index, subtree); },
-                None => { subtrees_guard.remove(&index); },
-            };
-        }
-        for (index, node_opt) in updates.upper_node_updates {
-            match node_opt {
-                Some(node) => { upper_nodes_guard.insert(index, node); },
-                None => { upper_nodes_guard.remove(&index); },
-            };
-        }
-        *root_guard = updates.new_root;
+        self.subtrees
+            .write()
+            .map_err(|_| {
+                StorageError::BackendError("Failed to acquire write lock for remove_subtree".into())
+            })?
+            .remove(&index);
         Ok(())
+    }
+
+    /// Retrieves a single inner node from a Subtree.
+    ///
+    /// This function is intended for accessing nodes within a Subtree, meaning
+    /// `index.depth()` must be greater than or equal to `IN_MEMORY_DEPTH`.
+    ///
+    /// # Errors
+    /// - `StorageError::BackendError`: If `index.depth() < IN_MEMORY_DEPTH`.
+    /// - `StorageError::BackendError`: If the read lock for subtrees cannot be acquired.
+    ///
+    /// Returns `Ok(None)` if the subtree or the specific inner node within it is not found.
+    fn get_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() < IN_MEMORY_DEPTH {
+            return Err(StorageError::BackendError(
+                "Cannot get inner node from upper part of the tree".to_string(),
+            ));
+        }
+        let subtree_root_index = Subtree::find_subtree_root(index);
+        let subtrees_guard = self.subtrees.read().map_err(|_| {
+            StorageError::BackendError(
+                "Failed to acquire read lock for get_inner_node (subtrees)".into(),
+            )
+        })?;
+        Ok(subtrees_guard
+            .get(&subtree_root_index)
+            .and_then(|subtree| subtree.get_inner_node(index)))
+    }
+
+    /// Sets a single inner node within a Subtree.
+    ///
+    /// - `index.depth()` must be greater than or equal to `IN_MEMORY_DEPTH`.
+    /// - If the target Subtree does not exist, it is created.
+    /// - The `node` is then inserted into the Subtree.
+    ///
+    /// Returns the `InnerNode` that was previously at this `index`, if any.
+    ///
+    /// # Errors
+    /// - `StorageError::BackendError`: If `index.depth() < IN_MEMORY_DEPTH`.
+    /// - `StorageError::BackendError`: If the write lock for subtrees cannot be acquired.
+    fn set_inner_node(
+        &self,
+        index: NodeIndex,
+        node: InnerNode,
+    ) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() < IN_MEMORY_DEPTH {
+            return Err(StorageError::BackendError(
+                "Cannot set inner node in upper part of the tree".to_string(),
+            ));
+        }
+        let subtree_root_index = Subtree::find_subtree_root(index);
+        let mut subtrees_guard = self.subtrees.write().map_err(|_| {
+            StorageError::BackendError(
+                "Failed to acquire write lock for set_inner_node (subtrees)".into(),
+            )
+        })?;
+        let mut subtree = subtrees_guard
+            .remove(&subtree_root_index)
+            .unwrap_or_else(|| Subtree::new(subtree_root_index));
+        let old_node = subtree.insert_inner_node(index, node);
+        subtrees_guard.insert(subtree_root_index, subtree);
+        Ok(old_node)
+    }
+
+    /// Removes a single inner node from a Subtree.
+    ///
+    /// - `index.depth()` must be greater than or equal to `IN_MEMORY_DEPTH`.
+    /// - If the Subtree becomes empty after removing the node, the Subtree itself is removed from
+    ///   storage.
+    ///
+    /// Returns the `InnerNode` that was removed, if any.
+    ///
+    /// # Errors
+    /// - `StorageError::BackendError`: If `index.depth() < IN_MEMORY_DEPTH`.
+    /// - `StorageError::BackendError`: If the write lock for subtrees cannot be acquired.
+    fn remove_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() < IN_MEMORY_DEPTH {
+            return Err(StorageError::BackendError(
+                "Cannot remove inner node from upper part of the tree".to_string(),
+            ));
+        }
+        let subtree_root_index = Subtree::find_subtree_root(index);
+        let mut subtrees_guard = self.subtrees.write().map_err(|_| {
+            StorageError::BackendError(
+                "Failed to acquire write lock for remove_inner_node (subtrees)".into(),
+            )
+        })?;
+
+        let inner_node: Option<InnerNode> =
+            subtrees_guard.remove(&subtree_root_index).and_then(|mut subtree| {
+                let old_node = subtree.remove_inner_node(index);
+                if !subtree.is_empty() {
+                    subtrees_guard.insert(subtree_root_index, subtree);
+                }
+                old_node
+            });
+        Ok(inner_node)
+    }
+
+    /// Applies a set of updates atomically to the storage.
+    ///
+    /// This method handles updates to:
+    /// - Leaves: Inserts new or updated leaves, removes specified leaves.
+    /// - Subtrees: Inserts new or updated subtrees, removes specified subtrees.
+    /// - Root hash: Sets the new root hash of the SMT.
+    ///
+    /// All operations are performed after acquiring write locks on the root, leaves, and subtrees
+    /// collections, ensuring atomicity of the batch update.
+    ///
+    /// # Errors
+    /// Returns `StorageError::BackendError` if any of the necessary write locks
+    /// (for root, leaves, or subtrees) cannot be acquired.
+    fn apply(&self, updates: StorageUpdates) -> Result<(), StorageError> {
+        let mut root_guard = self.root.write().map_err(|_| {
+            StorageError::BackendError("Failed to acquire write lock for root in apply".into())
+        })?;
+        let mut leaves_guard = self.leaves.write().map_err(|_| {
+            StorageError::BackendError("Failed to acquire write lock for leaves in apply".into())
+        })?;
+        let mut subtrees_guard = self.subtrees.write().map_err(|_| {
+            StorageError::BackendError("Failed to acquire write lock for subtrees in apply".into())
+        })?;
+
+        let (leaf_updates, subtree_updates, new_root, _leaf_count_delta, _entry_count_delta) =
+            updates.into_parts();
+
+        for (index, leaf_opt) in leaf_updates {
+            if let Some(leaf) = leaf_opt {
+                leaves_guard.insert(index, leaf);
+            } else {
+                leaves_guard.remove(&index);
+            }
+        }
+        for (index, subtree_opt) in subtree_updates {
+            if let Some(subtree) = subtree_opt {
+                subtrees_guard.insert(index, subtree);
+            } else {
+                subtrees_guard.remove(&index);
+            }
+        }
+        *root_guard = new_root;
+        Ok(())
+    }
+
+    /// Returns an iterator over all (index, SmtLeaf) pairs in the storage.
+    ///
+    /// The iterator provides access to the current state of the leaves.
+    ///
+    /// # Errors
+    /// Returns `StorageError::BackendError` if the read lock for leaves cannot be acquired.
+    fn iter_leaves(&self) -> Result<Box<dyn Iterator<Item = (u64, SmtLeaf)> + '_>, StorageError> {
+        let leaves_guard = self.leaves.read().map_err(|_| {
+            StorageError::BackendError("Failed to acquire read lock for iter_leaves".into())
+        })?;
+        let leaves_vec = leaves_guard.iter().map(|(&k, v)| (k, v.clone())).collect::<Vec<_>>();
+        Ok(Box::new(leaves_vec.into_iter()))
+    }
+
+    /// Returns an iterator over all Subtrees in the storage.
+    ///
+    /// The iterator provides access to the current subtrees from storage.
+    ///
+    /// # Errors
+    /// Returns `StorageError::BackendError` if the read lock for subtrees cannot be acquired.
+    fn iter_subtrees(&self) -> Result<Box<dyn Iterator<Item = Subtree> + '_>, StorageError> {
+        let subtrees_guard = self.subtrees.read().map_err(|_| {
+            StorageError::BackendError("Failed to acquire read lock for iter_subtrees".into())
+        })?;
+        let subtrees_vec = subtrees_guard.values().cloned().collect::<Vec<_>>();
+        Ok(Box::new(subtrees_vec.into_iter()))
+    }
+
+    /// Retrieves all depth 24 roots for fast tree rebuilding.
+    ///
+    /// For MemoryStorage, this returns an empty vector since all data is already in memory
+    /// and there's no startup performance benefit to caching depth 24 roots.
+    fn get_depth24(&self) -> Result<Vec<(u64, RpoDigest)>, StorageError> {
+        Ok(Vec::new())
     }
 }

--- a/miden-crypto/src/merkle/smt/full/large/storage/memory.rs
+++ b/miden-crypto/src/merkle/smt/full/large/storage/memory.rs
@@ -212,6 +212,14 @@ impl SmtStorage for MemoryStorage {
         Ok(leaves)
     }
 
+    /// Returns true if the storage has any leaves.
+    fn has_leaves(&self) -> Result<bool, StorageError> {
+        let leaves_guard = self.leaves.read().map_err(|_| {
+            StorageError::BackendError("Failed to acquire read lock for get_leaves".into())
+        })?;
+        Ok(!leaves_guard.is_empty())
+    }
+
     /// Retrieves a single Subtree (representing deep nodes) by its root NodeIndex.
     /// Assumes index.depth() >= IN_MEMORY_DEPTH. Returns Ok(None) if not found.
     fn get_subtree(&self, index: NodeIndex) -> Result<Option<Subtree>, StorageError> {

--- a/miden-crypto/src/merkle/smt/full/large/storage/memory.rs
+++ b/miden-crypto/src/merkle/smt/full/large/storage/memory.rs
@@ -1,0 +1,217 @@
+use alloc::vec::Vec;
+use std::sync::RwLock;
+use crate::merkle::smt::UnorderedMap;
+use crate::merkle::{EmptySubtreeRoots, InnerNode, NodeIndex, RpoDigest, SmtLeaf};
+use crate::merkle::smt::full::large::{subtree::Subtree, IN_MEMORY_DEPTH, SMT_DEPTH};
+
+use super::{SmtStorage, StorageError, StorageUpdates};
+
+#[derive(Debug)]
+pub struct MemoryStorage {
+    pub root: RwLock<RpoDigest>,
+    pub leaves: RwLock<UnorderedMap<u64, SmtLeaf>>,
+    pub subtrees: RwLock<UnorderedMap<NodeIndex, Subtree>>,
+    pub upper_nodes: RwLock<UnorderedMap<NodeIndex, InnerNode>>,
+}
+
+impl MemoryStorage {
+    pub fn new() -> Self {
+        let root_val = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
+        Self {
+            root: RwLock::new(root_val),
+            leaves: RwLock::new(UnorderedMap::new()),
+            subtrees: RwLock::new(UnorderedMap::new()),
+            upper_nodes: RwLock::new(UnorderedMap::new()),
+        }
+    }
+}
+
+impl Clone for MemoryStorage {
+    fn clone(&self) -> Self {
+        MemoryStorage {
+            root: RwLock::new(*self.root.read().expect("Failed to read lock for root in clone")),
+            leaves: RwLock::new(self.leaves.read().expect("Failed to read lock for leaves in clone").clone()),
+            subtrees: RwLock::new(self.subtrees.read().expect("Failed to read lock for subtrees in clone").clone()),
+            upper_nodes: RwLock::new(self.upper_nodes.read().expect("Failed to read lock for upper_nodes in clone").clone()),
+        }
+    }
+}
+
+impl SmtStorage for MemoryStorage {
+
+    fn get_root(&self) -> Result<Option<RpoDigest>, StorageError> {
+        Ok(Some(*self.root.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for root".into()))?))
+    }
+
+    /// Gets the total number of non-empty leaves currently stored.
+    fn get_leaf_count(&self) -> Result<usize, StorageError> {
+        Ok(self.leaves.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for leaves count".into()))?.len())
+    }   
+
+    /// Gets the total number of key-value entries currently stored.
+    fn get_entry_count(&self) -> Result<usize, StorageError> {
+        Ok(self.leaves.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for entry count".into()))?.len())
+    }
+
+    /// Retrieves a single leaf node.
+    fn get_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError> {
+        Ok(self.leaves.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_leaf".into()))?.get(&index).cloned())
+    }
+
+    /// Sets a single leaf node.
+    fn set_leaf(&self, index: u64, leaf: &SmtLeaf) -> Result<Option<SmtLeaf>, StorageError> {
+        Ok(self.leaves.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_leaf".into()))?.insert(index, leaf.clone()))
+    }
+
+    /// Sets multiple leaf nodes.
+    fn set_leaves(&self, leaves_map: UnorderedMap<u64, SmtLeaf>) -> Result<(), StorageError> {
+        let mut leaves_guard = self.leaves.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_leaves".into()))?;
+        for (index, leaf) in leaves_map {
+            leaves_guard.insert(index, leaf);
+        }
+        Ok(())
+    }
+
+    /// Removes a single leaf node.
+    fn remove_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError> {
+        Ok(self.leaves.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for remove_leaf".into()))?.remove(&index))
+    }
+
+    /// Retrieves multiple leaf nodes. Returns Ok(None) for indices not found.
+    fn get_leaves(&self, indices: &[u64]) -> Result<Vec<Option<SmtLeaf>>, StorageError> {
+        let leaves_guard = self.leaves.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_leaves".into()))?;
+        let mut res = Vec::with_capacity(indices.len());
+        for &idx in indices {
+            res.push(leaves_guard.get(&idx).cloned());
+        }
+        Ok(res)
+    }
+
+    /// Retrieves a single Subtree (representing deep nodes) by its root NodeIndex.
+    /// Assumes index.depth() > IN_MEMORY_DEPTH. Returns Ok(None) if not found.
+    fn get_subtree(&self, index: NodeIndex) -> Result<Option<Subtree>, StorageError> {
+        Ok(self.subtrees.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_subtree".into()))?.get(&index).cloned())
+    }
+
+    /// Retrieves multiple Subtrees.
+    /// Assumes index.depth() > IN_MEMORY_DEPTH for all indices. Returns Ok(None) for indices not found.
+    fn get_subtrees(&self, indices: &[NodeIndex]) -> Result<Vec<Option<Subtree>>, StorageError> {
+        let subtrees_guard = self.subtrees.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_subtrees".into()))?;
+        let mut res = Vec::with_capacity(indices.len());
+        for &idx in indices {
+            res.push(subtrees_guard.get(&idx).cloned());
+        }
+        Ok(res)
+    }
+
+    /// Sets a single Subtree (representing deep nodes) by its root NodeIndex.
+    fn set_subtree(&self, subtree: &Subtree) -> Result<(), StorageError> {
+        self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_subtree".into()))?.insert(subtree.root_index, subtree.clone());
+        Ok(())
+    }
+
+    /// Sets multiple Subtrees (representing deep nodes) by their root NodeIndex.
+    fn set_subtrees(&self, subtrees_vec: Vec<Subtree>) -> Result<(), StorageError> {
+        let mut subtrees_guard = self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_subtrees".into()))?;
+        for subtree in subtrees_vec {
+            subtrees_guard.insert(subtree.root_index, subtree);
+        }
+        Ok(())
+    }
+
+    /// Removes a single Subtree (representing deep nodes) by its root NodeIndex.
+    fn remove_subtree(&self, index: NodeIndex) -> Result<(), StorageError> {
+        self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for remove_subtree".into()))?.remove(&index);
+        Ok(())  
+    }
+
+    /// Retrieves a single inner node.
+    fn get_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() <= IN_MEMORY_DEPTH {
+            return Ok(self.upper_nodes.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_inner_node (upper)".into()))?.get(&index).cloned());
+        }
+        let subtree_root_index = Subtree::find_subtree_root(index);
+        let subtrees_guard = self.subtrees.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_inner_node (subtrees)".into()))?;
+        match subtrees_guard.get(&subtree_root_index) {
+            Some(subtree) => Ok(subtree.get_inner_node(index)),
+            None => Ok(None),
+        }
+    }
+
+    /// Retrieves multiple upper-level inner nodes by their indices.
+    fn get_upper_nodes(&self, indices: &[NodeIndex]) -> Result<Vec<Option<InnerNode>>, StorageError> {
+        let upper_nodes_guard = self.upper_nodes.read().map_err(|_| StorageError::BackendError("Failed to acquire read lock for get_upper_nodes".into()))?;
+        let mut res = Vec::with_capacity(indices.len());
+        for &idx in indices {
+            if idx.depth() <= IN_MEMORY_DEPTH {
+                res.push(upper_nodes_guard.get(&idx).cloned());
+            } else {
+                return Err(StorageError::OperationNotSupported("get_upper_nodes called with deep node index".into()));
+            }
+        }
+        Ok(res)
+    }
+
+    /// Sets a single inner node.
+    fn set_inner_node(&self, index: NodeIndex, node: InnerNode) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() <= IN_MEMORY_DEPTH {
+            Ok(self.upper_nodes.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_inner_node (upper)".into()))?.insert(index, node))
+        } else {
+            let subtree_root_index = Subtree::find_subtree_root(index);
+            let mut subtrees_guard = self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for set_inner_node (subtrees)".into()))?;
+            let mut subtree = subtrees_guard.remove(&subtree_root_index).unwrap_or_else(|| Subtree::new(subtree_root_index));
+            let old_node = subtree.insert_inner_node(index, node);
+            subtrees_guard.insert(subtree_root_index, subtree);
+            Ok(old_node)
+        }
+    }
+
+    /// Removes a single inner node.
+    fn remove_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() <= IN_MEMORY_DEPTH {
+            return Ok(self.upper_nodes.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for remove_inner_node (upper)".into()))?.remove(&index));
+        }
+        let subtree_root_index = Subtree::find_subtree_root(index);
+        let mut subtrees_guard = self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for remove_inner_node (subtrees)".into()))?;
+        if let Some(mut subtree) = subtrees_guard.remove(&subtree_root_index) {
+            let old_node = subtree.remove_inner_node(index);
+            if !subtree.is_empty() {
+                subtrees_guard.insert(subtree_root_index, subtree);
+            }
+            Ok(old_node)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Applies a set of updates atomically.
+    /// This includes updates to leaves, deep subtrees, upper nodes, the root hash,
+    /// and atomically updating persisted leaf/entry counts based on deltas.
+    fn apply_batch(&self, updates: StorageUpdates) -> Result<(), StorageError> {
+        let mut root_guard = self.root.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for root in apply_batch".into()))?;
+        let mut leaves_guard = self.leaves.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for leaves in apply_batch".into()))?;
+        let mut subtrees_guard = self.subtrees.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for subtrees in apply_batch".into()))?;
+        let mut upper_nodes_guard = self.upper_nodes.write().map_err(|_| StorageError::BackendError("Failed to acquire write lock for upper_nodes in apply_batch".into()))?;
+
+        for (index, leaf_opt) in updates.leaf_updates {
+            match leaf_opt {    
+                Some(leaf) => { leaves_guard.insert(index, leaf); },
+                None => { leaves_guard.remove(&index); },
+            };
+        }
+        for (index, subtree_opt) in updates.subtree_updates {
+            match subtree_opt {
+                Some(subtree) => { subtrees_guard.insert(index, subtree); },
+                None => { subtrees_guard.remove(&index); },
+            };
+        }
+        for (index, node_opt) in updates.upper_node_updates {
+            match node_opt {
+                Some(node) => { upper_nodes_guard.insert(index, node); },
+                None => { upper_nodes_guard.remove(&index); },
+            };
+        }
+        *root_guard = updates.new_root;
+        Ok(())
+    }
+}

--- a/miden-crypto/src/merkle/smt/full/large/storage/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/large/storage/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 #[cfg(feature = "rocksdb")]
 mod rocksdb;
 #[cfg(feature = "rocksdb")]
-pub use rocksdb::RocksDbStorage;
+pub use rocksdb::{RocksDbConfig, RocksDbStorage};
 
 mod memory;
 pub use memory::MemoryStorage;
@@ -324,6 +324,12 @@ pub trait SmtStorage: 'static + fmt::Debug + Send + Sync {
     /// For each `index` in the input, the corresponding element in the output `Vec`
     /// will be `Some(SmtLeaf)` if found, or `None` if not found.
     fn get_leaves(&self, indices: &[u64]) -> Result<Vec<Option<SmtLeaf>>, StorageError>;
+
+    /// Returns true if the storage has any leaves.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if the storage read operation fails.
+    fn has_leaves(&self) -> Result<bool, StorageError>;
 
     /// Retrieves a single SMT Subtree by its root `NodeIndex`.
     ///

--- a/miden-crypto/src/merkle/smt/full/large/storage/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/large/storage/mod.rs
@@ -1,27 +1,31 @@
-// Potential location: src/merkle/smt/storage.rs
-use thiserror::Error;
-
-use alloc::string::String;
-use alloc::vec::Vec;
-use crate::merkle::{NodeIndex, RpoDigest, SmtLeaf};
-use crate::merkle::smt::full::InnerNode; // Check path
-use crate::merkle::smt::full::large::subtree::Subtree; // Check path (Used for deep nodes)
-
-use alloc::collections::BTreeMap;
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt;
 
+use thiserror::Error;
+
+use crate::{
+    Word,
+    merkle::{
+        NodeIndex, RpoDigest, SmtLeaf,
+        smt::{
+            UnorderedMap,
+            full::{InnerNode, large::subtree::Subtree},
+        },
+    },
+};
+
+#[cfg(feature = "rocksdb")]
 mod rocksdb;
+#[cfg(feature = "rocksdb")]
 pub use rocksdb::RocksDbStorage;
 
 mod memory;
 pub use memory::MemoryStorage;
 
-use super::UnorderedMap;
-
-/// Custom error enum for storage operations.
+/// Defines the set of errors that can occur during SMT storage operations.
 #[derive(Debug, Error)]
 pub enum StorageError {
-    /// Error originating from the underlying storage backend (e.g., RocksDB error).
+    /// An error originating from the underlying storage backend (e.g., a database error).
     #[error("Storage backend error: {0}")]
     BackendError(String),
     /// Error during deserialization of data read from storage.
@@ -30,101 +34,376 @@ pub enum StorageError {
     /// Error during serialization of data before writing to storage.
     #[error("Serialization error: {0}")]
     SerializationError(String),
-    /// Requested item was not found (optional, could also be handled by Option).
+    /// Indicates that a requested item was not found in the storage.
     #[error("Item not found in storage")]
     NotFound,
-    /// An operation was attempted that is not supported by the storage implementation.
+    /// An operation was attempted that is not supported by the current storage implementation.
     #[error("Operation not supported: {0}")]
     OperationNotSupported(String),
-    /// Other storage-related errors.
+    /// A catch-all for other storage-related errors not covered by more specific variants.
+    /// Contains a string describing the error.
     #[error("Storage error: {0}")]
     Other(String),
 }
 
-/// Structure holding a collection of updates to be applied atomically to storage.
-#[derive(Default, Debug)]
+/// Represents a collection of changes to be applied atomically to an SMT storage backend.
+///
+/// This struct is used to batch multiple updates (to leaves, subtrees, and the SMT root)
+/// ensuring that they are persisted together as a single, consistent transaction.
+/// It also tracks deltas for leaf and entry counts, allowing storage implementations
+/// to maintain these counts accurately.
+#[derive(Default, Debug, Clone)]
 pub struct StorageUpdates {
-    /// Leaf updates: Map from logical leaf index (u64) to Option<SmtLeaf>.
-    /// Some(leaf) means insert/update, None means delete.
-    pub leaf_updates: BTreeMap<u64, Option<SmtLeaf>>,
+    /// A map of updates to individual SMT leaves.
+    /// The key is the logical leaf index (u64).
+    /// - `Some(SmtLeaf)` indicates an insertion or update of the leaf at that index.
+    /// - `None` indicates a deletion of the leaf at that index.
+    leaf_updates: UnorderedMap<u64, Option<SmtLeaf>>,
 
-    /// Subtree updates (for deep nodes, depth > IN_MEMORY_DEPTH):
-    /// Map from subtree root NodeIndex to Option<Subtree>.
-    /// Some(subtree) means insert/update, None means delete.
-    pub subtree_updates: BTreeMap<NodeIndex, Option<Subtree>>,
+    /// A map of updates to SMT subtrees.
+    /// The key is the `NodeIndex` of the subtree's root.
+    /// - `Some(Subtree)` indicates an insertion or update of the subtree.
+    /// - `None` indicates a deletion of the subtree.
+    subtree_updates: UnorderedMap<NodeIndex, Option<Subtree>>,
 
-    /// Upper node updates (for nodes with depth <= IN_MEMORY_DEPTH):
-    /// Map from NodeIndex to Option<InnerNode>.
-    /// Some(node) means insert/update, None means delete.
-    pub upper_node_updates: BTreeMap<NodeIndex, Option<InnerNode>>,
+    /// The new root hash of the SMT that should be persisted after applying
+    /// all `leaf_updates` and `subtree_updates`.
+    new_root: RpoDigest,
 
-    /// The new root hash to be persisted atomically with the other updates.
-    pub new_root: RpoDigest,
+    /// The net change in the total count of non-empty leaves resulting from this batch of updates.
+    /// For example, if one leaf is added and one is removed, this would be 0.
+    /// If two new leaves are added, this would be +2.
+    leaf_count_delta: isize,
 
-    /// Change in the total count of non-empty leaves for this batch.
-    pub leaf_count_delta: isize,
-
-    /// Change in the total count of key-value entries for this batch.
-    pub entry_count_delta: isize,
+    /// The net change in the total count of key-value entries across all leaves
+    /// resulting from this batch of updates.
+    entry_count_delta: isize,
 }
 
+impl StorageUpdates {
+    /// Creates a new `StorageUpdates` with the specified root hash and default empty updates.
+    ///
+    /// This constructor is ideal for incremental building where you'll add updates
+    /// one by one using the convenience methods like `insert_leaf()` and `insert_subtree()`.
+    pub fn new(new_root: RpoDigest) -> Self {
+        Self { new_root, ..Default::default() }
+    }
 
-pub trait SmtStorage: fmt::Debug + Send + Sync {
-    /// Retrieves the stored root hash of the SMT. Returns Ok(None) if not set.
+    /// Creates a new `StorageUpdates` from pre-computed components.
+    ///
+    /// This constructor is ideal for bulk operations where you already have
+    /// the complete maps of updates and calculated deltas, such as when applying
+    /// a batch of mutations.
+    pub fn from_parts(
+        leaf_updates: UnorderedMap<u64, Option<SmtLeaf>>,
+        subtree_updates: UnorderedMap<NodeIndex, Option<Subtree>>,
+        new_root: RpoDigest,
+        leaf_count_delta: isize,
+        entry_count_delta: isize,
+    ) -> Self {
+        Self {
+            leaf_updates,
+            subtree_updates,
+            new_root,
+            leaf_count_delta,
+            entry_count_delta,
+        }
+    }
+
+    /// Adds a leaf insertion/update to the batch.
+    pub fn insert_leaf(&mut self, index: u64, leaf: SmtLeaf) {
+        self.leaf_updates.insert(index, Some(leaf));
+    }
+
+    /// Adds a leaf removal to the batch.
+    pub fn remove_leaf(&mut self, index: u64) {
+        self.leaf_updates.insert(index, None);
+    }
+
+    /// Adds a subtree insertion/update to the batch.
+    pub fn insert_subtree(&mut self, subtree: Subtree) {
+        let index = subtree.root_index();
+        self.subtree_updates.insert(index, Some(subtree));
+    }
+
+    /// Adds a subtree removal to the batch.
+    pub fn remove_subtree(&mut self, index: NodeIndex) {
+        self.subtree_updates.insert(index, None);
+    }
+
+    /// Returns true if this update batch contains no changes.
+    pub fn is_empty(&self) -> bool {
+        self.leaf_updates.is_empty() && self.subtree_updates.is_empty()
+    }
+
+    /// Returns the number of leaf updates in this batch.
+    pub fn leaf_update_count(&self) -> usize {
+        self.leaf_updates.len()
+    }
+
+    /// Returns the number of subtree updates in this batch.
+    pub fn subtree_update_count(&self) -> usize {
+        self.subtree_updates.len()
+    }
+
+    /// Returns a reference to the leaf updates map.
+    pub fn leaf_updates(&self) -> &UnorderedMap<u64, Option<SmtLeaf>> {
+        &self.leaf_updates
+    }
+
+    /// Returns a reference to the subtree updates map.
+    pub fn subtree_updates(&self) -> &UnorderedMap<NodeIndex, Option<Subtree>> {
+        &self.subtree_updates
+    }
+
+    /// Returns the new root hash.
+    pub fn new_root(&self) -> RpoDigest {
+        self.new_root
+    }
+
+    /// Returns the leaf count delta.
+    pub fn leaf_count_delta(&self) -> isize {
+        self.leaf_count_delta
+    }
+
+    /// Returns the entry count delta.
+    pub fn entry_count_delta(&self) -> isize {
+        self.entry_count_delta
+    }
+
+    /// Sets the leaf count delta.
+    pub fn set_leaf_count_delta(&mut self, delta: isize) {
+        self.leaf_count_delta = delta;
+    }
+
+    /// Sets the entry count delta.
+    pub fn set_entry_count_delta(&mut self, delta: isize) {
+        self.entry_count_delta = delta;
+    }
+
+    /// Adjusts the leaf count delta by the specified amount.
+    pub fn adjust_leaf_count_delta(&mut self, adjustment: isize) {
+        self.leaf_count_delta += adjustment;
+    }
+
+    /// Adjusts the entry count delta by the specified amount.
+    pub fn adjust_entry_count_delta(&mut self, adjustment: isize) {
+        self.entry_count_delta += adjustment;
+    }
+
+    /// Consumes this StorageUpdates and returns the leaf updates map.
+    pub fn into_leaf_updates(self) -> UnorderedMap<u64, Option<SmtLeaf>> {
+        self.leaf_updates
+    }
+
+    /// Consumes this StorageUpdates and returns the subtree updates map.
+    pub fn into_subtree_updates(self) -> UnorderedMap<NodeIndex, Option<Subtree>> {
+        self.subtree_updates
+    }
+
+    /// Consumes this StorageUpdates and returns all components.
+    ///
+    /// First component is the leaf updates map.
+    /// Second component is the subtree updates map.
+    /// Third component is the new root hash.
+    /// Fourth component is the leaf count delta.
+    /// Fifth component is the entry count delta.
+    pub fn into_parts(
+        self,
+    ) -> (
+        UnorderedMap<u64, Option<SmtLeaf>>,
+        UnorderedMap<NodeIndex, Option<Subtree>>,
+        RpoDigest,
+        isize,
+        isize,
+    ) {
+        (
+            self.leaf_updates,
+            self.subtree_updates,
+            self.new_root,
+            self.leaf_count_delta,
+            self.entry_count_delta,
+        )
+    }
+}
+
+/// Sparse Merkle Tree storage backend.
+///
+/// This trait outlines the fundamental operations required to persist and retrieve
+/// the components of an SMT, such as its root hash, leaves, and deeper subtrees.
+/// Implementations of this trait can provide various storage solutions, like in-memory
+/// maps or persistent databases (e.g., RocksDB).
+///
+/// All methods are expected to handle potential storage errors by returning a
+/// `Result<_, StorageError>`.
+pub trait SmtStorage: 'static + fmt::Debug + Send + Sync {
+    /// Retrieves the current root hash of the Sparse Merkle Tree.
+    /// Returns `Ok(None)` if no root has been set or an empty SMT is represented.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if the storage read operation fails.
     fn get_root(&self) -> Result<Option<RpoDigest>, StorageError>;
 
-    /// Gets the total number of non-empty leaves currently stored.
-    fn get_leaf_count(&self) -> Result<usize, StorageError>;
+    /// Sets or updates the root hash of the Sparse Merkle Tree.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if the storage write operation fails.
+    fn set_root(&self, root: RpoDigest) -> Result<(), StorageError>;
 
-    /// Gets the total number of key-value entries currently stored.
-    fn get_entry_count(&self) -> Result<usize, StorageError>;
+    /// Retrieves the total number of leaf nodes currently stored.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if the storage read operation fails.
+    fn leaf_count(&self) -> Result<usize, StorageError>;
 
-    /// Retrieves a single leaf node.
+    /// Retrieves the total number of unique key-value entries across all leaf nodes.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if the storage read operation fails.
+    fn entry_count(&self) -> Result<usize, StorageError>;
+
+    /// Inserts a key-value pair into the SMT leaf at the specified logical `index`.
+    ///
+    /// - If the leaf at `index` does not exist, it may be created.
+    /// - If the `key` already exists in the leaf at `index`, its `value` is updated.
+    /// - Returns the previous `Word` value associated with the `key` at `index`, if any.
+    ///
+    /// Implementations are responsible for updating overall leaf and entry counts if necessary.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if the storage operation fails (e.g., backend database error,
+    /// insufficient space, serialization failures).
+    fn insert_value(
+        &self,
+        index: u64,
+        key: RpoDigest,
+        value: Word,
+    ) -> Result<Option<Word>, StorageError>;
+
+    /// Removes a key-value pair from the SMT leaf at the specified logical `index`.
+    ///
+    /// - If the `key` is found in the leaf at `index`, it is removed, and the old `Word` value is
+    ///   returned.
+    /// - If the leaf at `index` does not exist, or if the `key` is not found within it, `Ok(None)`
+    ///   is returned.
+    /// - If removing the entry causes the leaf to become empty, the behavior regarding the leaf
+    ///   node itself (e.g., whether it's removed from storage) is implementation-dependent, but
+    ///   counts should be updated.
+    ///
+    /// Implementations are responsible for updating overall leaf and entry counts if necessary.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if the storage operation fails (e.g., backend database error,
+    /// write permission issues, serialization failures).
+    fn remove_value(&self, index: u64, key: RpoDigest) -> Result<Option<Word>, StorageError>;
+
+    /// Retrieves a single SMT leaf node by its logical `index`.
+    /// Returns `Ok(None)` if no leaf exists at the given `index`.
     fn get_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError>;
 
-    /// Sets a single leaf node.
-    fn set_leaf(&self, index: u64, leaf: &SmtLeaf) -> Result<Option<SmtLeaf>, StorageError> ;
-
-    /// Sets multiple leaf nodes.
+    /// Sets or updates multiple SMT leaf nodes in storage.
+    ///
+    /// For each entry in the `leaves` map, if a leaf at the given index already exists,
+    /// it should be overwritten with the new `SmtLeaf` data.
+    /// If it does not exist, a new leaf is stored.
+    ///
+    /// # Errors
+    /// Returns `StorageError` if any storage operation fails during the batch update.
     fn set_leaves(&self, leaves: UnorderedMap<u64, SmtLeaf>) -> Result<(), StorageError>;
 
-    /// Removes a single leaf node.
+    /// Removes a single SMT leaf node entirely from storage by its logical `index`.
+    ///
+    /// Returns the `SmtLeaf` that was removed, or `Ok(None)` if no leaf existed at `index`.
+    /// Implementations should ensure that removing a leaf also correctly updates
+    /// the overall leaf and entry counts.
     fn remove_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError>;
 
-    /// Retrieves multiple leaf nodes. Returns Ok(None) for indices not found.
+    /// Retrieves multiple SMT leaf nodes by their logical `indices`.
+    ///
+    /// The returned `Vec` will have the same length as the input `indices` slice.
+    /// For each `index` in the input, the corresponding element in the output `Vec`
+    /// will be `Some(SmtLeaf)` if found, or `None` if not found.
     fn get_leaves(&self, indices: &[u64]) -> Result<Vec<Option<SmtLeaf>>, StorageError>;
 
-    /// Retrieves a single Subtree (representing deep nodes) by its root NodeIndex.
-    /// Assumes index.depth() > IN_MEMORY_DEPTH. Returns Ok(None) if not found.
+    /// Retrieves a single SMT Subtree by its root `NodeIndex`.
+    ///
+    /// Subtrees typically represent deeper, compacted parts of the SMT.
+    /// Returns `Ok(None)` if no subtree is found for the given `index`.
     fn get_subtree(&self, index: NodeIndex) -> Result<Option<Subtree>, StorageError>;
 
-    /// Retrieves multiple Subtrees.
-    /// Assumes index.depth() > IN_MEMORY_DEPTH for all indices. Returns Ok(None) for indices not found.
+    /// Retrieves multiple Subtrees by their root `NodeIndex` values.
+    ///
+    /// The returned `Vec` will have the same length as the input `indices` slice.
+    /// For each `index` in the input, the corresponding element in the output `Vec`
+    /// will be `Some(Subtree)` if found, or `None` if not found.
     fn get_subtrees(&self, indices: &[NodeIndex]) -> Result<Vec<Option<Subtree>>, StorageError>;
 
-    /// Sets a single Subtree (representing deep nodes) by its root NodeIndex.
+    /// Sets or updates a single SMT Subtree in storage, identified by its root `NodeIndex`.
+    ///
+    /// If a subtree with the same root `NodeIndex` already exists, it is overwritten.
     fn set_subtree(&self, subtree: &Subtree) -> Result<(), StorageError>;
 
-    /// Sets multiple Subtrees (representing deep nodes) by their root NodeIndex.
+    /// Sets or updates multiple SMT Subtrees in storage.
+    ///
+    /// For each `Subtree` in the `subtrees` vector, if a subtree with the same root `NodeIndex`
+    /// already exists, it is overwritten.
     fn set_subtrees(&self, subtrees: Vec<Subtree>) -> Result<(), StorageError>;
 
-    /// Removes a single Subtree (representing deep nodes) by its root NodeIndex.
+    /// Removes a single SMT Subtree from storage, identified by its root `NodeIndex`.
+    ///
+    /// Returns `Ok(())` on successful removal or if the subtree did not exist.
     fn remove_subtree(&self, index: NodeIndex) -> Result<(), StorageError>;
 
-    /// Retrieves a single inner node.
+    /// Retrieves a single inner node from within a Subtree.
+    ///
+    /// This method is intended for accessing nodes at depths greater than the in-memory horizon.
+    /// Returns `Ok(None)` if the containing Subtree or the specific inner node is not found.
     fn get_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError>;
 
-    /// Retrieves multiple upper-level inner nodes by their indices.
-    fn get_upper_nodes(&self, indices: &[NodeIndex]) -> Result<Vec<Option<InnerNode>>, StorageError>;
+    /// Sets or updates a single inner node (non-leaf node) within a Subtree.
+    ///
+    /// - If the target Subtree does not exist, it might need to be created by the implementation.
+    /// - Returns the `InnerNode` that was previously at this `index`, if any.
+    fn set_inner_node(
+        &self,
+        index: NodeIndex,
+        node: InnerNode,
+    ) -> Result<Option<InnerNode>, StorageError>;
 
-    /// Sets a single inner node.
-    fn set_inner_node(&self, index: NodeIndex, node: InnerNode) -> Result<Option<InnerNode>, StorageError>;
-
-    /// Removes a single inner node.
+    /// Removes a single inner node (non-leaf node) from within a Subtree.
+    ///
+    /// - If the Subtree becomes empty after removing the node, the Subtree itself might be removed
+    ///   by the storage implementation.
+    /// - Returns the `InnerNode` that was removed, if any.
     fn remove_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError>;
 
-    /// Applies a set of updates atomically.
-    /// This includes updates to leaves, deep subtrees, upper nodes, the root hash,
-    /// and atomically updating persisted leaf/entry counts based on deltas.
-    fn apply_batch(&self, updates: StorageUpdates) -> Result<(), StorageError>;
+    /// Applies a batch of `StorageUpdates` atomically to the storage backend.
+    ///
+    /// This is the primary method for persisting changes to the SMT. Implementations must ensure
+    /// that all updates within the `StorageUpdates` struct (leaf changes, subtree changes,
+    /// new root hash, and count deltas) are applied as a single, indivisible operation.
+    /// If any part of the update fails, the entire transaction should be rolled back, leaving
+    /// the storage in its previous state.
+    fn apply(&self, updates: StorageUpdates) -> Result<(), StorageError>;
+
+    /// Returns an iterator over all (logical_index, SmtLeaf) pairs currently in storage.
+    ///
+    /// The order of iteration is not guaranteed unless specified by the implementation.
+    fn iter_leaves(&self) -> Result<Box<dyn Iterator<Item = (u64, SmtLeaf)> + '_>, StorageError>;
+
+    /// Returns an iterator over all `Subtree` instances currently in storage.
+    ///
+    /// The order of iteration is not guaranteed unless specified by the implementation.
+    fn iter_subtrees(&self) -> Result<Box<dyn Iterator<Item = Subtree> + '_>, StorageError>;
+
+    /// Retrieves all depth 24 hashes from storage for efficient startup reconstruction.
+    ///
+    /// Returns a vector of `(node_index_value, InnerNode)` tuples representing
+    /// the cached roots of nodes at depth 24 (the in-memory/storage boundary).
+    /// These roots enable fast reconstruction of the upper tree without loading
+    /// entire subtrees.
+    ///
+    /// The hash cache is automatically maintained by subtree operations - no manual
+    /// cache management is required.
+    fn get_depth24(&self) -> Result<Vec<(u64, RpoDigest)>, StorageError>;
 }

--- a/miden-crypto/src/merkle/smt/full/large/storage/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/large/storage/mod.rs
@@ -1,0 +1,130 @@
+// Potential location: src/merkle/smt/storage.rs
+use thiserror::Error;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use crate::merkle::{NodeIndex, RpoDigest, SmtLeaf};
+use crate::merkle::smt::full::InnerNode; // Check path
+use crate::merkle::smt::full::large::subtree::Subtree; // Check path (Used for deep nodes)
+
+use alloc::collections::BTreeMap;
+use core::fmt;
+
+mod rocksdb;
+pub use rocksdb::RocksDbStorage;
+
+mod memory;
+pub use memory::MemoryStorage;
+
+use super::UnorderedMap;
+
+/// Custom error enum for storage operations.
+#[derive(Debug, Error)]
+pub enum StorageError {
+    /// Error originating from the underlying storage backend (e.g., RocksDB error).
+    #[error("Storage backend error: {0}")]
+    BackendError(String),
+    /// Error during deserialization of data read from storage.
+    #[error("Deserialization error: {0}")]
+    DeserializationError(String),
+    /// Error during serialization of data before writing to storage.
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+    /// Requested item was not found (optional, could also be handled by Option).
+    #[error("Item not found in storage")]
+    NotFound,
+    /// An operation was attempted that is not supported by the storage implementation.
+    #[error("Operation not supported: {0}")]
+    OperationNotSupported(String),
+    /// Other storage-related errors.
+    #[error("Storage error: {0}")]
+    Other(String),
+}
+
+/// Structure holding a collection of updates to be applied atomically to storage.
+#[derive(Default, Debug)]
+pub struct StorageUpdates {
+    /// Leaf updates: Map from logical leaf index (u64) to Option<SmtLeaf>.
+    /// Some(leaf) means insert/update, None means delete.
+    pub leaf_updates: BTreeMap<u64, Option<SmtLeaf>>,
+
+    /// Subtree updates (for deep nodes, depth > IN_MEMORY_DEPTH):
+    /// Map from subtree root NodeIndex to Option<Subtree>.
+    /// Some(subtree) means insert/update, None means delete.
+    pub subtree_updates: BTreeMap<NodeIndex, Option<Subtree>>,
+
+    /// Upper node updates (for nodes with depth <= IN_MEMORY_DEPTH):
+    /// Map from NodeIndex to Option<InnerNode>.
+    /// Some(node) means insert/update, None means delete.
+    pub upper_node_updates: BTreeMap<NodeIndex, Option<InnerNode>>,
+
+    /// The new root hash to be persisted atomically with the other updates.
+    pub new_root: RpoDigest,
+
+    /// Change in the total count of non-empty leaves for this batch.
+    pub leaf_count_delta: isize,
+
+    /// Change in the total count of key-value entries for this batch.
+    pub entry_count_delta: isize,
+}
+
+
+pub trait SmtStorage: fmt::Debug + Send + Sync {
+    /// Retrieves the stored root hash of the SMT. Returns Ok(None) if not set.
+    fn get_root(&self) -> Result<Option<RpoDigest>, StorageError>;
+
+    /// Gets the total number of non-empty leaves currently stored.
+    fn get_leaf_count(&self) -> Result<usize, StorageError>;
+
+    /// Gets the total number of key-value entries currently stored.
+    fn get_entry_count(&self) -> Result<usize, StorageError>;
+
+    /// Retrieves a single leaf node.
+    fn get_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError>;
+
+    /// Sets a single leaf node.
+    fn set_leaf(&self, index: u64, leaf: &SmtLeaf) -> Result<Option<SmtLeaf>, StorageError> ;
+
+    /// Sets multiple leaf nodes.
+    fn set_leaves(&self, leaves: UnorderedMap<u64, SmtLeaf>) -> Result<(), StorageError>;
+
+    /// Removes a single leaf node.
+    fn remove_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError>;
+
+    /// Retrieves multiple leaf nodes. Returns Ok(None) for indices not found.
+    fn get_leaves(&self, indices: &[u64]) -> Result<Vec<Option<SmtLeaf>>, StorageError>;
+
+    /// Retrieves a single Subtree (representing deep nodes) by its root NodeIndex.
+    /// Assumes index.depth() > IN_MEMORY_DEPTH. Returns Ok(None) if not found.
+    fn get_subtree(&self, index: NodeIndex) -> Result<Option<Subtree>, StorageError>;
+
+    /// Retrieves multiple Subtrees.
+    /// Assumes index.depth() > IN_MEMORY_DEPTH for all indices. Returns Ok(None) for indices not found.
+    fn get_subtrees(&self, indices: &[NodeIndex]) -> Result<Vec<Option<Subtree>>, StorageError>;
+
+    /// Sets a single Subtree (representing deep nodes) by its root NodeIndex.
+    fn set_subtree(&self, subtree: &Subtree) -> Result<(), StorageError>;
+
+    /// Sets multiple Subtrees (representing deep nodes) by their root NodeIndex.
+    fn set_subtrees(&self, subtrees: Vec<Subtree>) -> Result<(), StorageError>;
+
+    /// Removes a single Subtree (representing deep nodes) by its root NodeIndex.
+    fn remove_subtree(&self, index: NodeIndex) -> Result<(), StorageError>;
+
+    /// Retrieves a single inner node.
+    fn get_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError>;
+
+    /// Retrieves multiple upper-level inner nodes by their indices.
+    fn get_upper_nodes(&self, indices: &[NodeIndex]) -> Result<Vec<Option<InnerNode>>, StorageError>;
+
+    /// Sets a single inner node.
+    fn set_inner_node(&self, index: NodeIndex, node: InnerNode) -> Result<Option<InnerNode>, StorageError>;
+
+    /// Removes a single inner node.
+    fn remove_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError>;
+
+    /// Applies a set of updates atomically.
+    /// This includes updates to leaves, deep subtrees, upper nodes, the root hash,
+    /// and atomically updating persisted leaf/entry counts based on deltas.
+    fn apply_batch(&self, updates: StorageUpdates) -> Result<(), StorageError>;
+}

--- a/miden-crypto/src/merkle/smt/full/large/storage/rocksdb.rs
+++ b/miden-crypto/src/merkle/smt/full/large/storage/rocksdb.rs
@@ -1,0 +1,403 @@
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use rayon::prelude::*;
+use super::{SmtStorage, StorageError, StorageUpdates};
+use crate::merkle::{InnerNode, NodeIndex, RpoDigest, SmtLeaf};
+use crate::merkle::smt::full::large::{subtree::Subtree, IN_MEMORY_DEPTH};
+use crate::merkle::smt::UnorderedMap;
+use rocksdb::{BlockBasedOptions, Cache, ColumnFamilyDescriptor, DB, DBCompressionType, Options, WriteBatch};
+use std::path::PathBuf;
+use std::sync::Arc;
+use winter_utils::{Deserializable, Serializable};
+
+const LEAVES_CF: &str = "leaves";
+const SUBTREES_CF: &str = "subtrees";
+const UPPER_NODES_CF: &str = "upper_nodes";
+const METADATA_CF: &str = "metadata";
+
+const ROOT_KEY: &[u8] = b"smt_root";
+const LEAF_COUNT_KEY: &[u8] = b"leaf_count";
+const ENTRY_COUNT_KEY: &[u8] = b"entry_count";
+
+
+#[derive(Debug, Clone)]
+pub struct RocksDbStorage {
+    db: Arc<DB>,
+}
+
+impl RocksDbStorage {
+    pub fn open(path: &PathBuf) -> Result<Self, StorageError> {
+        let mut db_opts = Options::default();
+        db_opts.create_if_missing(true);
+        db_opts.create_missing_column_families(true);
+        db_opts.increase_parallelism(rayon::current_num_threads() as i32);
+        db_opts.set_max_open_files(512);
+
+        let cache = Cache::new_lru_cache(1024 * 1024 * 1024);
+
+        let mut leaves_table_opts = BlockBasedOptions::default();
+        leaves_table_opts.set_block_cache(&cache);
+        let mut leaves_opts = Options::default();
+        leaves_opts.set_block_based_table_factory(&leaves_table_opts);
+        //leaves_opts.set_compression_type(DBCompressionType::Lz4);
+
+        let mut subtrees_table_opts = BlockBasedOptions::default();
+        subtrees_table_opts.set_block_cache(&cache);
+        let mut subtrees_opts = Options::default();
+        subtrees_opts.set_block_based_table_factory(&subtrees_table_opts);
+        //subtrees_opts.set_compression_type(DBCompressionType::Lz4);
+
+        let mut upper_nodes_table_opts = BlockBasedOptions::default();
+        upper_nodes_table_opts.set_block_cache(&cache);
+        let mut upper_nodes_opts = Options::default();
+        upper_nodes_opts.set_block_based_table_factory(&upper_nodes_table_opts);
+        //upper_nodes_opts.set_compression_type(DBCompressionType::Lz4);
+
+        let metadata_table_opts = BlockBasedOptions::default();
+        let mut metadata_opts = Options::default();
+        metadata_opts.set_block_based_table_factory(&metadata_table_opts);
+        metadata_opts.set_compression_type(DBCompressionType::None);
+
+        let cfs = vec![
+            ColumnFamilyDescriptor::new(LEAVES_CF, leaves_opts),
+            ColumnFamilyDescriptor::new(SUBTREES_CF, subtrees_opts),
+            ColumnFamilyDescriptor::new(UPPER_NODES_CF, upper_nodes_opts),
+            ColumnFamilyDescriptor::new(METADATA_CF, metadata_opts),
+        ];
+
+        let db = DB::open_cf_descriptors(&db_opts, &path, cfs)
+            .map_err(|e| StorageError::BackendError(format!("Failed to open DB: {}", e)))?;
+
+        Ok(Self { db: Arc::new(db) })
+    }
+
+    #[inline(always)]
+    fn leaf_db_key(index: u64) -> [u8; 8] { index.to_be_bytes() }
+
+    #[inline(always)]
+    fn subtree_db_key(index: NodeIndex) -> [u8; 9] { Subtree::subtree_key(index) }
+
+    #[inline(always)]
+    fn upper_node_db_key(index: NodeIndex) -> [u8; 9] {
+        let mut key = [0u8; 9];
+        key[0] = index.depth();
+        key[1..].copy_from_slice(&index.value().to_be_bytes());
+        key
+    }
+
+    fn cf_handle(&self, name: &str) -> Result<&rocksdb::ColumnFamily, StorageError> {
+        self.db.cf_handle(name).ok_or_else(|| StorageError::BackendError(format!("CF '{}' missing", name)))
+    }
+}
+
+impl SmtStorage for RocksDbStorage {
+    fn get_root(&self) -> Result<Option<RpoDigest>, StorageError> {
+        let cf = self.cf_handle(METADATA_CF)?;
+        match self.db.get_cf(cf, ROOT_KEY).map_err(|e| StorageError::BackendError(e.to_string()))? {
+            Some(bytes) => {
+                let digest = RpoDigest::read_from_bytes(&bytes)
+                    .map_err(|e| StorageError::DeserializationError(e.to_string()))?;
+                Ok(Some(digest))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn get_leaf_count(&self) -> Result<usize, StorageError> {
+        let cf = self.cf_handle(METADATA_CF)?;
+        match self.db.get_cf(cf, LEAF_COUNT_KEY).map_err(|e| StorageError::BackendError(e.to_string()))? {
+            Some(bytes) => {
+                if bytes.len() == 8 {
+                    Ok(usize::from_be_bytes(bytes.try_into().unwrap()))
+                } else {
+                    Err(StorageError::DeserializationError("Invalid byte length for leaf count".to_string()))
+                }
+            }
+            None => Ok(0),
+        }
+    }
+
+    fn get_entry_count(&self) -> Result<usize, StorageError> {
+         let cf = self.cf_handle(METADATA_CF)?;
+         match self.db.get_cf(cf, ENTRY_COUNT_KEY).map_err(|e| StorageError::BackendError(e.to_string()))? {
+             Some(bytes) => {
+                 if bytes.len() == 8 {
+                     Ok(usize::from_be_bytes(bytes.try_into().unwrap()))
+                 } else {
+                     Err(StorageError::DeserializationError("Invalid byte length for entry count".to_string()))
+                 }
+             }
+             None => Ok(0),
+         }
+    }
+
+    fn get_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError> {
+        let cf = self.cf_handle(LEAVES_CF)?;
+        let key = Self::leaf_db_key(index);
+        match self.db.get_cf(cf, &key).map_err(|e| StorageError::BackendError(e.to_string()))? {
+            Some(bytes) => {
+                 let leaf = SmtLeaf::read_from_bytes(&bytes)
+                      .map_err(|e| StorageError::DeserializationError(e.to_string()))?;
+                  Ok(Some(leaf))
+             },
+             None => Ok(None),
+         }
+    }
+
+    fn set_leaf(&self, index: u64, leaf: &SmtLeaf) -> Result<Option<SmtLeaf>, StorageError> {
+        let cf = self.cf_handle(LEAVES_CF)?;
+        let key = Self::leaf_db_key(index);
+        let old_bytes = self.db.get_cf(cf, &key).ok().flatten();
+        let value = leaf.to_bytes();
+        self.db
+            .put_cf(cf, &key, &value)
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+        Ok(old_bytes
+            .map(|bytes| SmtLeaf::read_from_bytes(&bytes).expect("failed to deserialize leaf")))
+    }
+
+    fn set_leaves(&self, leaves: UnorderedMap<u64, SmtLeaf>) -> Result<(), StorageError> {
+        let cf = self.cf_handle(LEAVES_CF)?;
+        let mut batch = WriteBatch::default();
+        for (idx, leaf) in leaves {
+            let key = Self::leaf_db_key(idx);
+            let value = leaf.to_bytes();
+            batch.put_cf(cf, &key, &value);
+        }
+        self.db.write(batch).map_err(|e| StorageError::BackendError(e.to_string()))?;
+        Ok(())
+    }
+
+    fn remove_leaf(&self, index: u64) -> Result<Option<SmtLeaf>, StorageError> {
+        let key = Self::leaf_db_key(index);
+        let cf = self.cf_handle(LEAVES_CF)?;
+        let old_bytes = self.db.get_cf(cf, &key).ok().flatten();
+        self.db.delete_cf(cf, &key).map_err(|e| StorageError::BackendError(e.to_string()))?;
+        Ok(old_bytes.map(|bytes| SmtLeaf::read_from_bytes(&bytes).expect("failed to deserialize leaf")))
+    }
+
+    fn get_leaves(&self, indices: &[u64]) -> Result<Vec<Option<SmtLeaf>>, StorageError> {
+        let cf = self.cf_handle(LEAVES_CF)?;
+        let db_keys: Vec<[u8; 8]> = indices.iter().map(|&idx| Self::leaf_db_key(idx)).collect();
+        let results = self.db.multi_get_cf(db_keys.iter().map(|k| (cf, k.as_ref())));
+
+        results.into_iter().map(|result| {
+            match result {
+                Ok(Some(bytes)) => SmtLeaf::read_from_bytes(&bytes)
+                                    .map(Some)
+                                    .map_err(|e| StorageError::DeserializationError(e.to_string())),
+                Ok(None) => Ok(None),
+                Err(e) => Err(StorageError::BackendError(e.to_string())),
+            }
+        }).collect()
+    }
+
+    fn get_subtree(&self, index: NodeIndex) -> Result<Option<Subtree>, StorageError> {
+        let cf = self.cf_handle(SUBTREES_CF)?;
+        let key = Self::subtree_db_key(index);
+         match self.db.get_cf(cf, &key).map_err(|e| StorageError::BackendError(e.to_string()))? {
+             Some(bytes) => {
+                  let subtree = Subtree::from_vec(index, &bytes)
+                       .map_err(|e| StorageError::DeserializationError(e.to_string()))?;
+                   Ok(Some(subtree))
+              },
+              None => Ok(None),
+          }
+    }
+
+    fn get_subtrees(&self, indices: &[NodeIndex]) -> Result<Vec<Option<Subtree>>, StorageError> {
+        let cf = self.cf_handle(SUBTREES_CF)?;
+        let db_keys: Vec<[u8; 9]> = indices.iter().map(|&idx| Self::subtree_db_key(idx)).collect();
+        let results = self.db.multi_get_cf(db_keys.iter().map(|k| (cf, k)));
+
+        results.into_iter().zip(indices).map(|(result, index)| {
+            match result {
+                Ok(Some(bytes)) => {
+                    Subtree::from_vec(*index, &bytes)
+                        .map(Some)
+                        .map_err(|e| StorageError::DeserializationError(e.to_string()))
+                },
+                Ok(None) => Ok(None),
+                Err(e) => Err(StorageError::BackendError(e.to_string())),
+            }
+        }).collect()
+    }
+
+    fn set_subtree(&self, subtree: &Subtree) -> Result<(), StorageError> {
+        let cf = self.cf_handle(SUBTREES_CF)?;
+        let key = Self::subtree_db_key(subtree.root_index);
+        self.db.put_cf(cf, &key, subtree.to_vec()).map_err(|e| StorageError::BackendError(e.to_string()))?;
+        Ok(())
+    }
+
+    fn set_subtrees(&self, subtrees: Vec<Subtree>) -> Result<(), StorageError> {
+        let cf = self.cf_handle(SUBTREES_CF)?;
+        let mut batch = WriteBatch::default();
+        let serialized: Vec<([u8; 9], Vec<u8>)> = subtrees
+        .into_par_iter()
+        .map(|subtree| {
+            let key = Self::subtree_db_key(subtree.root_index);
+            let value = subtree.to_vec();
+            (key, value)
+        })
+        .collect();
+        for (key, value) in serialized {
+            batch.put_cf(cf, &key, value);
+        }
+        self.db.write(batch).map_err(|e| StorageError::BackendError(e.to_string()))?;
+        Ok(())
+    }
+
+    fn remove_subtree(&self, index: NodeIndex) -> Result<(), StorageError> {
+        let cf = self.cf_handle(SUBTREES_CF)?;
+        let key = Self::subtree_db_key(index);
+        self.db.delete_cf(cf, &key).map_err(|e| StorageError::BackendError(e.to_string()))?;
+        Ok(())
+    }
+
+    fn get_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() <= IN_MEMORY_DEPTH {
+            let cf = self.cf_handle(UPPER_NODES_CF)?;
+            let key = Self::upper_node_db_key(index);
+            match self.db.get_cf(cf, &key).map_err(|e| StorageError::BackendError(e.to_string()))? {
+                Some(bytes) => {
+                    let node = InnerNode::read_from_bytes(&bytes)
+                        .map_err(|e| StorageError::DeserializationError(e.to_string()))?;
+                    return Ok(Some(node));
+                },
+                None => return Ok(None),
+            }
+        }
+        let subtree_root_index = Subtree::find_subtree_root(index);
+        let subtree = self.get_subtree(subtree_root_index).expect("failed to get subtree");
+        if let Some(subtree) = subtree {
+            Ok(subtree.get_inner_node(index))
+        } else {
+            Ok(None)
+        }
+    }   
+
+    fn get_upper_nodes(&self, indices: &[NodeIndex]) -> Result<Vec<Option<InnerNode>>, StorageError> {
+        let cf = self.cf_handle(UPPER_NODES_CF)?;
+        let db_keys: Vec<[u8; 9]> = indices.iter().map(|&idx| Self::upper_node_db_key(idx)).collect();
+        let results = self.db.multi_get_cf(db_keys.iter().map(|k| (cf, k)));
+        results.into_iter().map(|result| {
+            match result {
+                Ok(Some(bytes)) => InnerNode::read_from_bytes(&bytes)
+                                    .map(Some)
+                                    .map_err(|e| StorageError::DeserializationError(e.to_string())),
+                Ok(None) => Ok(None),
+                Err(e) => Err(StorageError::BackendError(e.into_string())),
+            }
+        }).collect()
+    }
+
+    fn set_inner_node(&self, index: NodeIndex, node: InnerNode) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() <= IN_MEMORY_DEPTH {
+            let cf = self.cf_handle(UPPER_NODES_CF)?;
+            let key = Self::upper_node_db_key(index);
+            let old_bytes = self.db.get_cf(cf, &key).ok().flatten();
+            let value = node.to_bytes();
+            self.db
+                .put_cf(cf, &key, &value)
+                .map_err(|e| StorageError::BackendError(e.to_string()))?;
+            Ok(old_bytes.map(|bytes| {
+                InnerNode::read_from_bytes(&bytes).expect("failed to deserialize inner node")
+            }))
+        } else {
+            let subtree_root_index = Subtree::find_subtree_root(index);
+            let mut subtree = self
+                .get_subtree(subtree_root_index)?
+                .unwrap_or_else(|| Subtree::new(subtree_root_index));
+            let old_node = subtree.insert_inner_node(index, node);
+            self.set_subtree(&subtree)?;
+            Ok(old_node)
+        }
+    }
+
+    fn remove_inner_node(&self, index: NodeIndex) -> Result<Option<InnerNode>, StorageError> {
+        if index.depth() <= IN_MEMORY_DEPTH {
+            let cf = self.cf_handle(UPPER_NODES_CF)?;
+            let key = Self::upper_node_db_key(index);
+            let old_bytes = self.db.get_cf(cf, &key).ok().flatten();
+            self.db
+                .delete_cf(cf, &key)
+                .map_err(|e| StorageError::BackendError(e.to_string()))?;
+            Ok(old_bytes.map(|bytes| {
+                InnerNode::read_from_bytes(&bytes).expect("failed to deserialize inner node")
+            }))
+        } else {
+            let subtree_root_index = Subtree::find_subtree_root(index);
+            if let Some(mut subtree) = self.get_subtree(subtree_root_index)? {
+                let old_node = subtree.remove_inner_node(index);
+                if subtree.is_empty() {
+                    self.remove_subtree(subtree_root_index)?;
+                } else {
+                    self.set_subtree(&subtree)?;
+                }
+                Ok(old_node)
+            } else {
+                // Subtree not found, so the node within it is also not found.
+                Ok(None)
+            }
+        }
+    }
+
+    fn apply_batch(&self, updates: StorageUpdates) -> Result<(), StorageError> {
+        let mut batch = WriteBatch::default();
+
+        let leaves_cf = self.cf_handle(LEAVES_CF)?;
+        let subtrees_cf = self.cf_handle(SUBTREES_CF)?;
+        let upper_nodes_cf = self.cf_handle(UPPER_NODES_CF)?;
+        let metadata_cf = self.cf_handle(METADATA_CF)?;
+
+        for (index, maybe_leaf) in updates.leaf_updates {
+            let key = Self::leaf_db_key(index);
+            match maybe_leaf {
+                Some(leaf) => {
+                    let bytes = leaf.to_bytes();
+                    batch.put_cf(leaves_cf, &key, bytes);
+                },
+                None => batch.delete_cf(leaves_cf, &key),
+            }
+        }
+
+        for (index, maybe_subtree) in updates.subtree_updates {
+             let key = Self::subtree_db_key(index);
+             match maybe_subtree {
+                 Some(subtree) => {
+                     let bytes = subtree.to_vec();
+                     batch.put_cf(subtrees_cf, &key, bytes);
+                 },
+                 None => batch.delete_cf(subtrees_cf, &key),
+             }
+        }
+
+        for (index, maybe_node) in updates.upper_node_updates {
+            let key = Self::upper_node_db_key(index);
+            match maybe_node {
+                Some(node) => {
+                    let bytes = node.to_bytes();
+                    batch.put_cf(upper_nodes_cf, &key, bytes);
+                }
+                None => batch.delete_cf(upper_nodes_cf, &key),
+            }
+        }
+
+        if updates.leaf_count_delta != 0 || updates.entry_count_delta != 0 {
+            let current_leaf_count = self.get_leaf_count()?;
+            let current_entry_count = self.get_entry_count()?;
+
+            let new_leaf_count = current_leaf_count.saturating_add_signed(updates.leaf_count_delta);
+            let new_entry_count = current_entry_count.saturating_add_signed(updates.entry_count_delta);
+
+            batch.put_cf(metadata_cf, LEAF_COUNT_KEY, &new_leaf_count.to_be_bytes());
+            batch.put_cf(metadata_cf, ENTRY_COUNT_KEY, &new_entry_count.to_be_bytes());
+        }
+
+        batch.put_cf(metadata_cf, ROOT_KEY, updates.new_root.to_bytes());
+
+        self.db.write(batch).map_err(|e| StorageError::BackendError(e.to_string()))?;
+        Ok(())
+    }
+}

--- a/miden-crypto/src/merkle/smt/full/large/subtree.rs
+++ b/miden-crypto/src/merkle/smt/full/large/subtree.rs
@@ -1,0 +1,152 @@
+use alloc::vec::Vec;
+use crate::merkle::smt::UnorderedMap;
+use super::{InnerNode, NodeIndex, RpoDigest, SUBTREE_DEPTH};
+use crate::utils::{Deserializable, DeserializationError};
+
+/// Represents a complete 8-depth subtree that can be serialized into a single RocksDB entry.
+#[derive(Debug, Clone)]
+pub struct Subtree {
+    pub root_index: NodeIndex,
+    // Store only non-empty nodes in a HashMap
+    nodes: UnorderedMap<u8, InnerNode>,
+    // Cache for the number of present nodes to optimize serialization
+    present_nodes: usize,
+}
+
+impl Subtree {
+    pub const DEPTH: usize = 8;
+    pub const NODE_COUNT: usize = (1 << Self::DEPTH) - 1; // 2^8 - 1 = 255
+    const NODE_SIZE: usize = 64; // 32 bytes for left + 32 bytes for right
+    const BITMASK_SIZE: usize = 32;
+
+    pub fn new(root_index: NodeIndex) -> Self {
+        Self {
+            root_index,
+            nodes: UnorderedMap::new(),
+            present_nodes: 0,
+        }
+    }
+
+    pub fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) -> Option<InnerNode> {
+        let local_index = Self::global_to_local(index, self.root_index);
+        let old_value = self.nodes.insert(local_index, inner_node);
+        if old_value.is_none() {
+            self.present_nodes += 1;
+        }
+        old_value
+    }
+
+    pub fn remove_inner_node(&mut self, index: NodeIndex) -> Option<InnerNode> {
+        let local_index = Self::global_to_local(index, self.root_index);
+        let old_value = self.nodes.remove(&local_index);
+        if old_value.is_some() {
+            self.present_nodes -= 1;
+        }
+        old_value
+    }
+
+    pub fn get_inner_node(&self, index: NodeIndex) -> Option<InnerNode> {
+        let local_index = Self::global_to_local(index, self.root_index);
+        self.nodes.get(&local_index).cloned()
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        // Pre-allocate the exact size needed
+        let mut buf = Vec::with_capacity(Self::BITMASK_SIZE + self.present_nodes * Self::NODE_SIZE);
+
+        // Create and write bitmask
+        let mut bitmask = [0u8; Self::BITMASK_SIZE];
+        for &local_index in self.nodes.keys() {
+            bitmask[local_index as usize / 8] |= 1 << (local_index % 8);
+        }
+        buf.extend_from_slice(&bitmask);
+
+        // Write node data in order
+        for local_index in 0..Self::NODE_COUNT as u8 {
+            if let Some(node) = self.nodes.get(&local_index) {
+                buf.extend_from_slice(&node.left.as_bytes());
+                buf.extend_from_slice(&node.right.as_bytes());
+            }
+        }
+
+        buf
+    }
+
+    pub fn from_vec(root_index: NodeIndex, data: Vec<u8>) -> Result<Self, DeserializationError> {
+        if data.len() < Self::BITMASK_SIZE {
+            return Err(DeserializationError::InvalidValue("Subtree data too short".into()));
+        }
+
+        let (bitmask, node_data) = data.split_at(Self::BITMASK_SIZE);
+        let mut nodes = UnorderedMap::new();
+        let mut present_nodes = 0;
+        let mut cursor = 0;
+
+        // Pre-calculate the number of present nodes from the bitmask
+        for &byte in bitmask {
+            present_nodes += byte.count_ones() as usize;
+        }
+
+        // Pre-allocate the node data vector if we know the exact size
+        let node_data = node_data.to_vec();
+        if node_data.len() != present_nodes * Self::NODE_SIZE {
+            return Err(DeserializationError::InvalidValue("Invalid node data length".into()));
+        }
+
+        for (i, &byte) in bitmask.iter().enumerate() {
+            for bit in 0..8 {
+                if (byte >> bit) & 1 != 0 {
+                    let local_index = (i * 8 + bit) as u8;
+                    let node_start = cursor * Self::NODE_SIZE;
+                    let node_end = node_start + Self::NODE_SIZE;
+                    
+                    let node_bytes = &node_data[node_start..node_end];
+                    let left = RpoDigest::read_from_bytes(&node_bytes[..32])?;
+                    let right = RpoDigest::read_from_bytes(&node_bytes[32..])?;
+                    
+                    nodes.insert(local_index, InnerNode { left, right });
+                    cursor += 1;
+                }
+            }
+        }
+
+        Ok(Self { 
+            root_index, 
+            nodes,
+            present_nodes,
+        })
+    }
+
+    fn global_to_local(global: NodeIndex, base: NodeIndex) -> u8 {
+        assert!(global.depth() >= base.depth(), "Global depth is less than base depth = {}, global depth = {}", base.depth(), global.depth());
+        
+        // Calculate the relative position within the subtree
+        let relative_depth = global.depth() - base.depth();
+        // The mask to get the relative position bits
+        let mask = (1 << relative_depth) - 1;
+        // Get the relative position and add the offset for the subtree level
+        ((1 << relative_depth) - 1) + ((global.value() & mask) as u8)
+    }
+
+    pub fn subtree_key(root_index: NodeIndex) -> Vec<u8> {
+        let mut key = Vec::with_capacity(10); // 1 + 1 + 8 bytes
+        key.push(b'S');
+        key.push(root_index.depth());
+        key.extend_from_slice(&root_index.value().to_le_bytes());
+        key
+    }
+    
+    pub fn find_subtree_root(node_index: NodeIndex) -> NodeIndex {
+        let depth = node_index.depth();
+        if depth < SUBTREE_DEPTH {
+            NodeIndex::root()
+        } else {
+            // Calculate subtree root depth and value in one go
+            let subtree_root_depth = depth - (depth % SUBTREE_DEPTH);
+            let relative_depth = depth - subtree_root_depth;
+            let base_value = node_index.value() >> relative_depth;
+            
+            NodeIndex::new(subtree_root_depth, base_value).unwrap()
+        }
+    }
+}

--- a/miden-crypto/src/merkle/smt/full/large/subtree.rs
+++ b/miden-crypto/src/merkle/smt/full/large/subtree.rs
@@ -27,6 +27,10 @@ impl Subtree {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.present_nodes
+    }
+
     pub fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) -> Option<InnerNode> {
         let local_index = Self::global_to_local(index, self.root_index);
         let old_value = self.nodes.insert(local_index, inner_node);
@@ -72,47 +76,46 @@ impl Subtree {
         buf
     }
 
-    pub fn from_vec(root_index: NodeIndex, data: Vec<u8>) -> Result<Self, DeserializationError> {
+    pub fn from_vec(root_index: NodeIndex, data: &Vec<u8>) -> Result<Self, DeserializationError> {
         if data.len() < Self::BITMASK_SIZE {
             return Err(DeserializationError::InvalidValue("Subtree data too short".into()));
         }
-
+    
         let (bitmask, node_data) = data.split_at(Self::BITMASK_SIZE);
+    
         let mut nodes = UnorderedMap::new();
         let mut present_nodes = 0;
         let mut cursor = 0;
-
-        // Pre-calculate the number of present nodes from the bitmask
+    
+        // Pre-calculate number of present nodes
         for &byte in bitmask {
             present_nodes += byte.count_ones() as usize;
         }
-
-        // Pre-allocate the node data vector if we know the exact size
-        let node_data = node_data.to_vec();
+    
         if node_data.len() != present_nodes * Self::NODE_SIZE {
             return Err(DeserializationError::InvalidValue("Invalid node data length".into()));
         }
-
+    
         for (i, &byte) in bitmask.iter().enumerate() {
             for bit in 0..8 {
                 if (byte >> bit) & 1 != 0 {
                     let local_index = (i * 8 + bit) as u8;
+    
                     let node_start = cursor * Self::NODE_SIZE;
-                    let node_end = node_start + Self::NODE_SIZE;
-                    
-                    let node_bytes = &node_data[node_start..node_end];
+                    let node_bytes = &node_data[node_start..node_start + Self::NODE_SIZE];
+    
                     let left = RpoDigest::read_from_bytes(&node_bytes[..32])?;
                     let right = RpoDigest::read_from_bytes(&node_bytes[32..])?;
-                    
+    
                     nodes.insert(local_index, InnerNode { left, right });
                     cursor += 1;
                 }
             }
         }
-
+    
         Ok(Self { 
             root_index, 
-            nodes,
+            nodes, 
             present_nodes,
         })
     }
@@ -128,11 +131,10 @@ impl Subtree {
         ((1 << relative_depth) - 1) + ((global.value() & mask) as u8)
     }
 
-    pub fn subtree_key(root_index: NodeIndex) -> Vec<u8> {
-        let mut key = Vec::with_capacity(10); // 1 + 1 + 8 bytes
-        key.push(b'S');
-        key.push(root_index.depth());
-        key.extend_from_slice(&root_index.value().to_le_bytes());
+    pub fn subtree_key(root_index: NodeIndex) -> [u8; 9]{
+        let mut key = [0u8; 9]; // 8 bytes
+        key[0] = root_index.depth();
+        key[1..].copy_from_slice(&root_index.value().to_be_bytes());
         key
     }
     
@@ -148,5 +150,9 @@ impl Subtree {
             
             NodeIndex::new(subtree_root_depth, base_value).unwrap()
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.present_nodes == 0
     }
 }

--- a/miden-crypto/src/merkle/smt/full/large/subtree/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/large/subtree/mod.rs
@@ -1,13 +1,19 @@
 use alloc::vec::Vec;
-use crate::merkle::smt::UnorderedMap;
-use super::{InnerNode, NodeIndex, RpoDigest, SUBTREE_DEPTH};
-use crate::utils::{Deserializable, DeserializationError};
+
+use super::{InnerNode, InnerNodeInfo, NodeIndex, Rpo256, RpoDigest, SUBTREE_DEPTH};
+use crate::{
+    merkle::smt::UnorderedMap,
+    utils::{Deserializable, DeserializationError},
+};
+
+#[cfg(test)]
+mod tests;
 
 /// Represents a complete 8-depth subtree that can be serialized into a single RocksDB entry.
 #[derive(Debug, Clone)]
 pub struct Subtree {
-    pub root_index: NodeIndex,
-    // Store only non-empty nodes in a HashMap
+    root_index: NodeIndex,
+    // Store only non-empty nodes in a map
     nodes: UnorderedMap<u8, InnerNode>,
     // Cache for the number of present nodes to optimize serialization
     present_nodes: usize,
@@ -15,8 +21,8 @@ pub struct Subtree {
 
 impl Subtree {
     pub const DEPTH: usize = 8;
-    pub const NODE_COUNT: usize = (1 << Self::DEPTH) - 1; // 2^8 - 1 = 255
-    const NODE_SIZE: usize = 64; // 32 bytes for left + 32 bytes for right
+    pub const NODE_COUNT: usize = (1 << Self::DEPTH) - 1;
+    const NODE_SIZE: usize = 64;
     const BITMASK_SIZE: usize = 32;
 
     pub fn new(root_index: NodeIndex) -> Self {
@@ -27,11 +33,19 @@ impl Subtree {
         }
     }
 
+    pub fn root_index(&self) -> NodeIndex {
+        self.root_index
+    }
+
     pub fn len(&self) -> usize {
         self.present_nodes
     }
 
-    pub fn insert_inner_node(&mut self, index: NodeIndex, inner_node: InnerNode) -> Option<InnerNode> {
+    pub fn insert_inner_node(
+        &mut self,
+        index: NodeIndex,
+        inner_node: InnerNode,
+    ) -> Option<InnerNode> {
         let local_index = Self::global_to_local(index, self.root_index);
         let old_value = self.nodes.insert(local_index, inner_node);
         if old_value.is_none() {
@@ -76,53 +90,63 @@ impl Subtree {
         buf
     }
 
-    pub fn from_vec(root_index: NodeIndex, data: &Vec<u8>) -> Result<Self, DeserializationError> {
+    pub fn from_vec(root_index: NodeIndex, data: &[u8]) -> Result<Self, DeserializationError> {
         if data.len() < Self::BITMASK_SIZE {
             return Err(DeserializationError::InvalidValue("Subtree data too short".into()));
         }
-    
         let (bitmask, node_data) = data.split_at(Self::BITMASK_SIZE);
-    
-        let mut nodes = UnorderedMap::new();
-        let mut present_nodes = 0;
-        let mut cursor = 0;
-    
-        // Pre-calculate number of present nodes
-        for &byte in bitmask {
-            present_nodes += byte.count_ones() as usize;
-        }
-    
+        let present_nodes: usize = bitmask.iter().map(|&byte| byte.count_ones() as usize).sum();
         if node_data.len() != present_nodes * Self::NODE_SIZE {
             return Err(DeserializationError::InvalidValue("Invalid node data length".into()));
         }
-    
-        for (i, &byte) in bitmask.iter().enumerate() {
-            for bit in 0..8 {
-                if (byte >> bit) & 1 != 0 {
-                    let local_index = (i * 8 + bit) as u8;
-    
-                    let node_start = cursor * Self::NODE_SIZE;
-                    let node_bytes = &node_data[node_start..node_start + Self::NODE_SIZE];
-    
-                    let left = RpoDigest::read_from_bytes(&node_bytes[..32])?;
-                    let right = RpoDigest::read_from_bytes(&node_bytes[32..])?;
-    
-                    nodes.insert(local_index, InnerNode { left, right });
-                    cursor += 1;
-                }
-            }
+
+        let mut nodes = UnorderedMap::new();
+        let mut node_data_chunks = node_data.chunks_exact(Self::NODE_SIZE);
+        bitmask
+            .iter()
+            .enumerate()
+            .flat_map(|(byte_idx, &byte_val)| {
+                (0..8_u8).filter_map(move |bit_pos_in_byte| {
+                    if (byte_val >> bit_pos_in_byte) & 1 != 0 {
+                        let local_index = (byte_idx as u8 * 8) + bit_pos_in_byte;
+                        Some(local_index)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .try_for_each(|local_index| -> Result<(), DeserializationError> {
+                let node_bytes = node_data_chunks.next().ok_or_else(|| {
+                    DeserializationError::InvalidValue(
+                        "Bitmask indicates more nodes than present in node_data".into(),
+                    )
+                })?;
+
+                let left = RpoDigest::read_from_bytes(&node_bytes[..32])?;
+                let right = RpoDigest::read_from_bytes(&node_bytes[32..])?;
+
+                nodes.insert(local_index, InnerNode { left, right });
+                Ok(())
+            })?;
+
+        // Ensure all expected node data was consumed
+        if node_data_chunks.next().is_some() {
+            return Err(DeserializationError::InvalidValue(
+                "Node data is longer than indicated by the bitmask".into(),
+            ));
         }
-    
-        Ok(Self { 
-            root_index, 
-            nodes, 
-            present_nodes,
-        })
+
+        Ok(Self { root_index, nodes, present_nodes })
     }
 
     fn global_to_local(global: NodeIndex, base: NodeIndex) -> u8 {
-        assert!(global.depth() >= base.depth(), "Global depth is less than base depth = {}, global depth = {}", base.depth(), global.depth());
-        
+        assert!(
+            global.depth() >= base.depth(),
+            "Global depth is less than base depth = {}, global depth = {}",
+            base.depth(),
+            global.depth()
+        );
+
         // Calculate the relative position within the subtree
         let relative_depth = global.depth() - base.depth();
         // The mask to get the relative position bits
@@ -131,28 +155,35 @@ impl Subtree {
         ((1 << relative_depth) - 1) + ((global.value() & mask) as u8)
     }
 
-    pub fn subtree_key(root_index: NodeIndex) -> [u8; 9]{
-        let mut key = [0u8; 9]; // 8 bytes
+    pub fn subtree_key(root_index: NodeIndex) -> [u8; 9] {
+        let mut key = [0u8; 9];
         key[0] = root_index.depth();
         key[1..].copy_from_slice(&root_index.value().to_be_bytes());
         key
     }
-    
+
     pub fn find_subtree_root(node_index: NodeIndex) -> NodeIndex {
         let depth = node_index.depth();
         if depth < SUBTREE_DEPTH {
             NodeIndex::root()
         } else {
-            // Calculate subtree root depth and value in one go
             let subtree_root_depth = depth - (depth % SUBTREE_DEPTH);
             let relative_depth = depth - subtree_root_depth;
             let base_value = node_index.value() >> relative_depth;
-            
+
             NodeIndex::new(subtree_root_depth, base_value).unwrap()
         }
     }
 
     pub fn is_empty(&self) -> bool {
         self.present_nodes == 0
+    }
+
+    pub fn iter_inner_node_info(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
+        self.nodes.values().map(|inner_node_ref| InnerNodeInfo {
+            value: Rpo256::merge(&[inner_node_ref.left, inner_node_ref.right]),
+            left: inner_node_ref.left,
+            right: inner_node_ref.right,
+        })
     }
 }

--- a/miden-crypto/src/merkle/smt/full/large/subtree/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/large/subtree/mod.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use super::{InnerNode, InnerNodeInfo, NodeIndex, Rpo256, RpoDigest, SUBTREE_DEPTH};
+use super::{InnerNode, InnerNodeInfo, NodeIndex, SUBTREE_DEPTH};
 use crate::{
     merkle::smt::UnorderedMap,
     utils::{Deserializable, DeserializationError},
@@ -20,8 +20,8 @@ pub struct Subtree {
 }
 
 impl Subtree {
-    pub const DEPTH: usize = 8;
-    pub const NODE_COUNT: usize = (1 << Self::DEPTH) - 1;
+    const DEPTH: usize = 8;
+    const NODE_COUNT: usize = (1 << Self::DEPTH) - 1;
     const NODE_SIZE: usize = 64;
     const BITMASK_SIZE: usize = 32;
 
@@ -122,10 +122,10 @@ impl Subtree {
                     )
                 })?;
 
-                let left = RpoDigest::read_from_bytes(&node_bytes[..32])?;
-                let right = RpoDigest::read_from_bytes(&node_bytes[32..])?;
-
-                nodes.insert(local_index, InnerNode { left, right });
+                //let left = RpoDigest::read_from_bytes(&node_bytes[..32])?;
+                //let right = RpoDigest::read_from_bytes(&node_bytes[32..])?;
+                let node = InnerNode::read_from_bytes(node_bytes)?;
+                nodes.insert(local_index, node);
                 Ok(())
             })?;
 
@@ -181,7 +181,7 @@ impl Subtree {
 
     pub fn iter_inner_node_info(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
         self.nodes.values().map(|inner_node_ref| InnerNodeInfo {
-            value: Rpo256::merge(&[inner_node_ref.left, inner_node_ref.right]),
+            value: inner_node_ref.hash(),
             left: inner_node_ref.left,
             right: inner_node_ref.right,
         })

--- a/miden-crypto/src/merkle/smt/full/large/subtree/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/large/subtree/tests.rs
@@ -1,0 +1,339 @@
+use super::{InnerNode, NodeIndex, RpoDigest, SUBTREE_DEPTH, Subtree};
+
+#[test]
+fn test_initial_state() {
+    let root_index = NodeIndex::new(SUBTREE_DEPTH, 0).unwrap();
+    let subtree = Subtree::new(root_index);
+
+    assert_eq!(subtree.root_index(), root_index, "Root index should match the provided index");
+    assert_eq!(subtree.len(), 0, "New subtree should be empty");
+    assert!(subtree.is_empty(), "New subtree should report as empty");
+    assert_eq!(subtree.present_nodes, 0, "New subtree should have no present nodes");
+    assert!(subtree.nodes.is_empty(), "New subtree's node storage should be empty");
+}
+
+#[test]
+fn test_node_operations() {
+    let subtree_root_idx = NodeIndex::new(SUBTREE_DEPTH, 0).unwrap();
+    let mut subtree = Subtree::new(subtree_root_idx);
+
+    // Create test nodes and indices
+    let node1_idx = NodeIndex::new(SUBTREE_DEPTH + 1, 0).unwrap();
+    let node1 = InnerNode {
+        left: RpoDigest::default(),
+        right: RpoDigest::default(),
+    };
+
+    let node2_idx = NodeIndex::new(SUBTREE_DEPTH + 2, 3).unwrap();
+    let node2 = InnerNode {
+        left: RpoDigest::from([1u32; 4]),
+        right: RpoDigest::from([2u32; 4]),
+    };
+
+    // Test insertion into empty subtree
+    assert_eq!(subtree.len(), 0, "Subtree should be empty");
+
+    let old_node = subtree.insert_inner_node(node1_idx, node1.clone());
+    assert!(old_node.is_none(), "Old node should be empty");
+    assert_eq!(subtree.len(), 1, "Subtree should have one node");
+    assert_eq!(subtree.present_nodes, 1, "Present nodes count should be 1");
+
+    let old_node = subtree.insert_inner_node(node2_idx, node2.clone());
+    assert!(old_node.is_none(), "Old node should be empty");
+    assert_eq!(subtree.len(), 2, "Subtree should have two nodes");
+    assert_eq!(subtree.present_nodes, 2, "Present nodes count should be 2");
+
+    // Test node retrieval
+    assert_eq!(
+        subtree.get_inner_node(node1_idx),
+        Some(node1.clone()),
+        "Should match the first node"
+    );
+    assert_eq!(
+        subtree.get_inner_node(node2_idx),
+        Some(node2.clone()),
+        "Should match the second node"
+    );
+
+    let non_existent_idx = NodeIndex::new(SUBTREE_DEPTH + 3, 0).unwrap();
+    assert!(
+        subtree.get_inner_node(non_existent_idx).is_none(),
+        "Should return None for non-existent node"
+    );
+
+    // Test node overwriting
+    let node1_updated = InnerNode {
+        left: RpoDigest::from([3u32; 4]),
+        right: RpoDigest::from([4u32; 4]),
+    };
+    let previous_node = subtree.insert_inner_node(node1_idx, node1_updated.clone());
+    assert_eq!(previous_node, Some(node1), "Overwriting should return the previous node");
+    assert_eq!(subtree.len(), 2, "Length should not change on overwrite");
+    assert_eq!(subtree.present_nodes, 2, "Present nodes count should remain the same");
+    assert_eq!(
+        subtree.get_inner_node(node1_idx),
+        Some(node1_updated.clone()),
+        "Should retrieve the updated node"
+    );
+
+    // Test node removal
+    let removed_node = subtree.remove_inner_node(node1_idx);
+    assert_eq!(removed_node, Some(node1_updated), "Removing should return the removed node");
+    assert_eq!(subtree.len(), 1, "Length should decrease after removal");
+    assert_eq!(subtree.present_nodes, 1, "Present nodes count should decrease");
+    assert!(
+        subtree.get_inner_node(node1_idx).is_none(),
+        "Removed node should no longer be retrievable"
+    );
+
+    // Test removing non-existent node
+    let remove_result = subtree.remove_inner_node(node1_idx);
+    assert!(remove_result.is_none(), "Removing non-existent node should return None");
+    assert_eq!(subtree.len(), 1, "Length should not change when removing non-existent node");
+    assert_eq!(subtree.present_nodes, 1, "Present nodes count should not change");
+
+    // Remove final node to test empty state
+    let removed_node = subtree.remove_inner_node(node2_idx);
+    assert_eq!(removed_node, Some(node2), "Should remove the final node");
+    assert_eq!(subtree.len(), 0, "Subtree should be empty after removing all nodes");
+    assert_eq!(subtree.present_nodes, 0, "Present nodes count should be zero");
+    assert!(subtree.is_empty(), "Subtree should report as empty");
+
+    // Test removing from empty subtree
+    let remove_result = subtree.remove_inner_node(node1_idx);
+    assert!(remove_result.is_none(), "Removing from empty subtree should return None");
+    assert_eq!(subtree.len(), 0, "Length should remain zero");
+}
+
+#[test]
+fn test_serialize_deserialize_empty_subtree() {
+    let root_index = NodeIndex::new(SUBTREE_DEPTH, 1).unwrap();
+    let subtree = Subtree::new(root_index);
+
+    let serialized = subtree.to_vec();
+
+    // Should only contain the bitmask (all zeros) and no node data
+    assert_eq!(
+        serialized.len(),
+        Subtree::BITMASK_SIZE,
+        "Empty subtree serialization should only contain bitmask"
+    );
+    assert!(
+        serialized.iter().all(|&byte| byte == 0),
+        "All bytes in empty subtree serialization should be zero"
+    );
+
+    let deserialized = Subtree::from_vec(root_index, &serialized)
+        .expect("Deserialization of empty subtree should succeed");
+
+    assert_eq!(deserialized.root_index(), root_index, "Deserialized root index should match");
+    assert!(deserialized.is_empty(), "Deserialized subtree should be empty");
+    assert_eq!(deserialized.len(), 0, "Deserialized subtree should have length 0");
+}
+
+#[test]
+fn test_serialize_deserialize_subtree_with_nodes() {
+    let subtree_root_idx = NodeIndex::new(SUBTREE_DEPTH, 0).unwrap();
+    let mut subtree = Subtree::new(subtree_root_idx);
+
+    // Add nodes at positions: root (local index 0), first child (local index 1),
+    // and last possible position (local index 254)
+    let node0_idx_global = NodeIndex::new(SUBTREE_DEPTH, 0).unwrap();
+    let node1_idx_global = NodeIndex::new(SUBTREE_DEPTH + 1, 0).unwrap();
+    let node254_idx_global = NodeIndex::new(SUBTREE_DEPTH + 7, 127).unwrap();
+
+    let node0 = InnerNode {
+        left: RpoDigest::from([1u32; 4]),
+        right: RpoDigest::from([2u32; 4]),
+    };
+    let node1 = InnerNode {
+        left: RpoDigest::from([3u32; 4]),
+        right: RpoDigest::from([4u32; 4]),
+    };
+    let node254 = InnerNode {
+        left: RpoDigest::from([5u32; 4]),
+        right: RpoDigest::from([6u32; 4]),
+    };
+
+    subtree.insert_inner_node(node0_idx_global, node0.clone());
+    subtree.insert_inner_node(node1_idx_global, node1.clone());
+    subtree.insert_inner_node(node254_idx_global, node254.clone());
+
+    assert_eq!(subtree.len(), 3, "Subtree should contain 3 nodes");
+
+    // Test serialization
+    let serialized = subtree.to_vec();
+    let expected_size = Subtree::BITMASK_SIZE + 3 * Subtree::NODE_SIZE;
+    assert_eq!(serialized.len(), expected_size, "Serialized size should be bitmask + 3 nodes");
+
+    // Test deserialization
+    let deserialized =
+        Subtree::from_vec(subtree_root_idx, &serialized).expect("Deserialization should succeed");
+
+    assert_eq!(deserialized.root_index(), subtree_root_idx, "Root index should match");
+    assert_eq!(deserialized.len(), 3, "Deserialized subtree should have 3 nodes");
+    assert!(!deserialized.is_empty(), "Deserialized subtree should not be empty");
+
+    // Verify all nodes are correctly deserialized
+    assert_eq!(
+        deserialized.get_inner_node(node0_idx_global),
+        Some(node0),
+        "First node should be correctly deserialized"
+    );
+    assert_eq!(
+        deserialized.get_inner_node(node1_idx_global),
+        Some(node1),
+        "Second node should be correctly deserialized"
+    );
+    assert_eq!(
+        deserialized.get_inner_node(node254_idx_global),
+        Some(node254),
+        "Third node should be correctly deserialized"
+    );
+
+    // Verify bitmask correctness
+    let (bitmask_bytes, _node_data) = serialized.split_at(Subtree::BITMASK_SIZE);
+
+    // local_idx 0: byte 0, bit 0
+    // local_idx 1: byte 0, bit 1
+    // local_idx 254: byte 31, bit 6
+    assert_eq!(bitmask_bytes[0], 0b0000_0011, "First byte should have bits 0 and 1 set");
+    assert!(
+        bitmask_bytes[1..31].iter().all(|&byte| byte == 0),
+        "Middle bytes should all be zero"
+    );
+    assert_eq!(bitmask_bytes[31], 1 << 6, "Last byte should have bit 6 set for local index 254");
+}
+
+/// Tests global to local index conversion with zero-based subtree root
+#[test]
+fn global_to_local_index_conversion_zero_base() {
+    let base_idx = NodeIndex::new(SUBTREE_DEPTH, 0).unwrap();
+
+    // Test various depth and value combinations
+    let test_cases = [
+        // (depth, value, expected_local_index, description)
+        (SUBTREE_DEPTH, 0, 0, "root node"),
+        (SUBTREE_DEPTH + 1, 0, 1, "left child"),
+        (SUBTREE_DEPTH + 1, 1, 2, "right child"),
+        (SUBTREE_DEPTH + 2, 0, 3, "left grandchild"),
+        (SUBTREE_DEPTH + 2, 3, 6, "right grandchild at position 3"),
+        (SUBTREE_DEPTH + 7, 0, 127, "deepest left node"),
+        (SUBTREE_DEPTH + 7, 127, 254, "deepest right node"),
+    ];
+
+    for (depth, value, expected_local, description) in test_cases {
+        let global_idx = NodeIndex::new(depth, value).unwrap();
+        let local_idx = Subtree::global_to_local(global_idx, base_idx);
+        assert_eq!(
+            local_idx, expected_local,
+            "Failed for {description}: depth={depth}, value={value}"
+        );
+    }
+}
+
+/// Tests global to local index conversion with non-zero subtree root
+#[test]
+fn global_to_local_index_conversion_nonzero_base() {
+    let base_idx = NodeIndex::new(SUBTREE_DEPTH * 2, 1).unwrap();
+
+    let test_cases = [
+        // (depth, value, expected_local_index, description)
+        (SUBTREE_DEPTH * 2, 1, 0, "subtree root itself"),
+        (SUBTREE_DEPTH * 2 + 1, 2, 1, "left child (2 = 1<<1 | 0)"),
+        (SUBTREE_DEPTH * 2 + 1, 3, 2, "right child (3 = 1<<1 | 1)"),
+    ];
+
+    for (depth, value, expected_local, description) in test_cases {
+        let global_idx = NodeIndex::new(depth, value).unwrap();
+        let local_idx = Subtree::global_to_local(global_idx, base_idx);
+        assert_eq!(
+            local_idx, expected_local,
+            "Failed for {description}: depth={depth}, value={value}"
+        );
+    }
+}
+
+/// Tests that global_to_local panics when global depth is less than base depth
+#[test]
+#[should_panic(expected = "Global depth is less than base depth")]
+fn global_to_local_panics_on_invalid_depth() {
+    let base_idx = NodeIndex::new(SUBTREE_DEPTH, 0).unwrap();
+    let invalid_global_idx = NodeIndex::new(SUBTREE_DEPTH - 1, 0).unwrap();
+
+    // This should panic because global depth cannot be less than base depth
+    Subtree::global_to_local(invalid_global_idx, base_idx);
+}
+
+/// Tests finding subtree roots for nodes at various positions in the tree
+#[test]
+fn find_subtree_root_for_various_nodes() {
+    // Test nodes within the first possible subtree (rooted at depth 0)
+    let shallow_nodes =
+        [NodeIndex::new(0, 0).unwrap(), NodeIndex::new(SUBTREE_DEPTH - 1, 0).unwrap()];
+
+    for node_idx in shallow_nodes {
+        assert_eq!(
+            Subtree::find_subtree_root(node_idx),
+            NodeIndex::root(),
+            "Node at depth {} should belong to root subtree",
+            node_idx.depth()
+        );
+    }
+
+    // Test nodes in subtree rooted at (depth=SUBTREE_DEPTH, value=0)
+    let subtree_0_root = NodeIndex::new(SUBTREE_DEPTH, 0).unwrap();
+    let subtree_0_nodes = [
+        NodeIndex::new(SUBTREE_DEPTH, 0).unwrap(),
+        NodeIndex::new(SUBTREE_DEPTH + 1, 0).unwrap(),
+        NodeIndex::new(SUBTREE_DEPTH + 1, 1).unwrap(),
+        NodeIndex::new(SUBTREE_DEPTH * 2 - 1, (1 << (SUBTREE_DEPTH - 1)) - 1).unwrap(),
+    ];
+
+    for node_idx in subtree_0_nodes {
+        assert_eq!(
+            Subtree::find_subtree_root(node_idx),
+            subtree_0_root,
+            "Node at depth {}, value {} should belong to subtree rooted at depth {}, value 0",
+            node_idx.depth(),
+            node_idx.value(),
+            SUBTREE_DEPTH
+        );
+    }
+
+    // Test nodes in subtree rooted at (depth=SUBTREE_DEPTH, value=1)
+    let subtree_1_root = NodeIndex::new(SUBTREE_DEPTH, 1).unwrap();
+    let subtree_1_nodes = [
+        NodeIndex::new(SUBTREE_DEPTH, 1).unwrap(),
+        NodeIndex::new(SUBTREE_DEPTH + 1, 2).unwrap(),
+        NodeIndex::new(SUBTREE_DEPTH + 1, 3).unwrap(),
+    ];
+
+    for node_idx in subtree_1_nodes {
+        assert_eq!(
+            Subtree::find_subtree_root(node_idx),
+            subtree_1_root,
+            "Node at depth {}, value {} should belong to subtree rooted at depth {}, value 1",
+            node_idx.depth(),
+            node_idx.value(),
+            SUBTREE_DEPTH
+        );
+    }
+
+    // Test nodes in subtree rooted at (depth=SUBTREE_DEPTH*2, value=3)
+    let deep_subtree_root = NodeIndex::new(SUBTREE_DEPTH * 2, 3).unwrap();
+    let deep_subtree_nodes = [
+        NodeIndex::new(SUBTREE_DEPTH * 2, 3).unwrap(),
+        NodeIndex::new(SUBTREE_DEPTH * 2 + 5, (3 << 5) | 17).unwrap(),
+    ];
+
+    for node_idx in deep_subtree_nodes {
+        assert_eq!(
+            Subtree::find_subtree_root(node_idx),
+            deep_subtree_root,
+            "Node at depth {}, value {} should belong to deep subtree",
+            node_idx.depth(),
+            node_idx.value()
+        );
+    }
+}

--- a/miden-crypto/src/merkle/smt/full/large/subtree/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/large/subtree/tests.rs
@@ -1,4 +1,5 @@
-use super::{InnerNode, NodeIndex, RpoDigest, SUBTREE_DEPTH, Subtree};
+use super::{InnerNode, NodeIndex, SUBTREE_DEPTH, Subtree};
+use crate::merkle::RpoDigest;
 
 #[test]
 fn test_initial_state() {

--- a/miden-crypto/src/merkle/smt/full/large/test_details.rs
+++ b/miden-crypto/src/merkle/smt/full/large/test_details.rs
@@ -1,0 +1,354 @@
+use alloc::{collections::BTreeSet, vec::Vec};
+
+use rand::{Rng, prelude::IteratorRandom, rng};
+
+use super::{
+    EMPTY_WORD, InnerNodeInfo, LargeSmt, LeafIndex, RpoDigest, SMT_DEPTH, SmtLeaf, SmtStorage, Word,
+};
+use crate::{
+    Felt, ONE, WORD_SIZE,
+    merkle::smt::full::{Smt, concurrent::COLS_PER_SUBTREE},
+};
+
+pub fn generate_entries(pair_count: u64) -> Vec<(RpoDigest, Word)> {
+    (0..pair_count)
+        .map(|i| {
+            let leaf_index = ((i as f64 / pair_count as f64) * (pair_count as f64)) as u64;
+            let key = RpoDigest::new([ONE, ONE, Felt::new(i), Felt::new(leaf_index)]);
+            let value = [ONE, ONE, ONE, Felt::new(i)];
+            (key, value)
+        })
+        .collect()
+}
+
+pub fn generate_updates(entries: Vec<(RpoDigest, Word)>, updates: usize) -> Vec<(RpoDigest, Word)> {
+    const REMOVAL_PROBABILITY: f64 = 0.2;
+    let mut rng = rng();
+    // Assertion to ensure input keys are unique
+    assert!(
+        entries.iter().map(|(key, _)| key).collect::<BTreeSet<_>>().len() == entries.len(),
+        "Input entries contain duplicate keys!"
+    );
+    let mut sorted_entries: Vec<(RpoDigest, Word)> = entries
+        .into_iter()
+        .choose_multiple(&mut rng, updates)
+        .into_iter()
+        .map(|(key, _)| {
+            let value = if rng.random_bool(REMOVAL_PROBABILITY) {
+                EMPTY_WORD
+            } else {
+                [ONE, ONE, ONE, Felt::new(rng.random())]
+            };
+            (key, value)
+        })
+        .collect();
+    // Sort by the 3rd Felt in the key
+    sorted_entries.sort_by_key(|(key, _)| key[3].as_int());
+    sorted_entries
+}
+
+pub fn create_equivalent_smts_for_testing<S: SmtStorage>(
+    storage: S,
+    entries: Vec<(RpoDigest, Word)>,
+) -> (Smt, LargeSmt<S>) {
+    let control_smt = Smt::with_entries(entries.clone()).unwrap();
+    let large_smt = LargeSmt::<S>::with_entries(storage, entries).unwrap();
+    (control_smt, large_smt)
+}
+
+pub fn smt_get_value<S: SmtStorage>(storage: S) {
+    let key_1: RpoDigest = RpoDigest::from([ONE, ONE, ONE, ONE]);
+    let key_2: RpoDigest = RpoDigest::from([2_u32, 2_u32, 2_u32, 2_u32]);
+
+    let value_1 = [ONE; WORD_SIZE];
+    let value_2 = [2_u32.into(); WORD_SIZE];
+    let smt = LargeSmt::<S>::with_entries(storage, [(key_1, value_1), (key_2, value_2)]).unwrap();
+
+    let returned_value_1 = smt.get_value(&key_1);
+    let returned_value_2 = smt.get_value(&key_2);
+
+    assert_eq!(value_1, returned_value_1);
+    assert_eq!(value_2, returned_value_2);
+
+    // Check that a key with no inserted value returns the empty word
+    let key_no_value = RpoDigest::from([42_u32, 42_u32, 42_u32, 42_u32]);
+
+    assert_eq!(EMPTY_WORD, smt.get_value(&key_no_value));
+}
+
+pub fn equivalent_roots<S: SmtStorage>(storage: S) {
+    let entries = generate_entries(1000);
+    let (control_smt, large_smt) = create_equivalent_smts_for_testing(storage, entries);
+    assert_eq!(control_smt.root(), large_smt.root());
+}
+
+pub fn equivalent_openings<S: SmtStorage>(storage: S) {
+    let entries = generate_entries(1000);
+    let (control_smt, large_smt) = create_equivalent_smts_for_testing(storage, entries.clone());
+
+    for (key, _) in entries {
+        assert_eq!(control_smt.open(&key), large_smt.open(&key));
+    }
+}
+
+pub fn equivalent_entry_sets<S: SmtStorage>(storage: S) {
+    let entries = generate_entries(1000);
+    let (control_smt, large_smt) = create_equivalent_smts_for_testing(storage, entries);
+
+    let mut entries_control_smt_owned: Vec<(RpoDigest, Word)> =
+        control_smt.entries().copied().collect();
+    let mut entries_large_smt: Vec<(RpoDigest, Word)> = large_smt.entries().collect();
+
+    entries_control_smt_owned.sort_by_key(|k| k.0);
+    entries_large_smt.sort_by_key(|k| k.0);
+
+    assert_eq!(entries_control_smt_owned, entries_large_smt);
+    assert_eq!(control_smt.num_leaves(), large_smt.num_leaves());
+    assert_eq!(control_smt.num_entries(), large_smt.num_entries());
+}
+
+pub fn equivalent_leaf_sets<S: SmtStorage>(storage: S) {
+    let entries = generate_entries(1000);
+    let (control_smt, large_smt) = create_equivalent_smts_for_testing(storage, entries);
+
+    let mut leaves_control_smt: Vec<(LeafIndex<SMT_DEPTH>, SmtLeaf)> =
+        control_smt.leaves().map(|(idx, leaf_ref)| (idx, leaf_ref.clone())).collect();
+    let mut leaves_large_smt: Vec<(LeafIndex<SMT_DEPTH>, SmtLeaf)> = large_smt.leaves().collect();
+
+    leaves_control_smt.sort_by_key(|k| k.0);
+    leaves_large_smt.sort_by_key(|k| k.0);
+
+    assert_eq!(leaves_control_smt.len(), leaves_large_smt.len());
+    assert_eq!(leaves_control_smt, leaves_large_smt);
+    assert_eq!(control_smt.num_leaves(), large_smt.num_leaves());
+    assert_eq!(control_smt.num_entries(), large_smt.num_entries());
+}
+
+pub fn equivalent_inner_nodes<S: SmtStorage>(storage: S) {
+    let entries = generate_entries(1000);
+    let (control_smt, large_smt) = create_equivalent_smts_for_testing(storage, entries);
+
+    let mut control_smt_inner_nodes: Vec<InnerNodeInfo> = control_smt.inner_nodes().collect();
+    let mut large_smt_inner_nodes: Vec<InnerNodeInfo> = large_smt.inner_nodes().collect();
+
+    control_smt_inner_nodes.sort_by_key(|info| info.value);
+    large_smt_inner_nodes.sort_by_key(|info| info.value);
+
+    assert_eq!(control_smt_inner_nodes.len(), large_smt_inner_nodes.len());
+    assert_eq!(control_smt_inner_nodes, large_smt_inner_nodes);
+}
+
+pub fn compute_mutations<S: SmtStorage>(storage: S) {
+    const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 64;
+    let entries = generate_entries(PAIR_COUNT);
+
+    let control_smt = Smt::with_entries(entries.clone()).unwrap();
+
+    let large_tree = LargeSmt::<S>::with_entries(storage, entries.clone()).unwrap();
+
+    let updates = generate_updates(entries, 1000);
+    let control_mutations = control_smt.compute_mutations(updates.clone());
+
+    let mutations = large_tree.compute_mutations(updates);
+    assert_eq!(mutations.root(), control_mutations.root());
+    assert_eq!(mutations.old_root(), control_mutations.old_root());
+    assert_eq!(mutations.node_mutations(), control_mutations.node_mutations());
+    assert_eq!(mutations.new_pairs(), control_mutations.new_pairs());
+}
+
+pub fn empty_smt<S: SmtStorage>(storage: S) {
+    let large_smt = LargeSmt::<S>::new(storage).expect("Failed to create empty SMT");
+
+    let empty_control_smt = Smt::new();
+    assert_eq!(large_smt.root(), empty_control_smt.root(), "Empty SMT root mismatch");
+
+    let random_key = RpoDigest::from([ONE, 2_u32.into(), 3_u32.into(), 4_u32.into()]);
+    assert_eq!(
+        large_smt.get_value(&random_key),
+        EMPTY_WORD,
+        "get_value on empty SMT should return EMPTY_WORD"
+    );
+
+    assert_eq!(large_smt.entries().count(), 0, "Empty SMT should have no entries");
+    assert_eq!(large_smt.leaves().count(), 0, "Empty SMT should have no leaves");
+    assert_eq!(large_smt.inner_nodes().count(), 0, "Empty SMT should have no inner nodes");
+}
+
+pub fn single_entry_smt<S: SmtStorage>(storage: S) {
+    let key = RpoDigest::from([ONE, ONE, ONE, ONE]);
+    let value = [ONE; WORD_SIZE];
+
+    // Create SMT with a single entry
+    let mut smt = LargeSmt::<S>::with_entries(storage, [(key, value)]).unwrap();
+
+    // Check root
+    let control_smt_single = Smt::with_entries([(key, value)]).unwrap();
+    assert_eq!(smt.root(), control_smt_single.root(), "Single entry SMT root mismatch");
+
+    // Check get_value for the existing key
+    assert_eq!(smt.get_value(&key), value, "get_value for existing key failed");
+
+    // Check get_value for a non-existing key
+    let other_key = RpoDigest::from([2_u32, 2_u32, 2_u32, 2_u32]);
+    assert_eq!(smt.get_value(&other_key), EMPTY_WORD, "get_value for non-existing key failed");
+
+    // Check entries iterator
+    let entries: Vec<_> = smt.entries().collect();
+    assert_eq!(entries.len(), 1, "Single entry SMT should have one entry");
+    assert_eq!(entries[0], (key, value), "Single entry SMT entry mismatch");
+
+    // Update the entry
+    let new_value = [2_u32.into(); WORD_SIZE];
+    let mutations = smt.compute_mutations(vec![(key, new_value)]);
+
+    // test opening before mutations
+    assert_eq!(
+        smt.open(&key),
+        control_smt_single.open(&key),
+        "Opening before mutations mismatch"
+    );
+
+    smt.apply_mutations(mutations).unwrap();
+
+    let control_smt_updated = Smt::with_entries([(key, new_value)]).unwrap();
+    assert_eq!(smt.root(), control_smt_updated.root(), "Updated SMT root mismatch");
+    assert_eq!(smt.get_value(&key), new_value, "get_value after update failed");
+
+    // test opening after mutations
+    assert_eq!(
+        smt.open(&key),
+        control_smt_updated.open(&key),
+        "Opening after mutations mismatch"
+    );
+
+    // "Delete" the entry by updating its value to EMPTY_WORD
+    let mutations_delete = smt.compute_mutations(vec![(key, EMPTY_WORD)]);
+    smt.apply_mutations(mutations_delete).unwrap();
+
+    let empty_control_smt = Smt::new();
+    assert_eq!(smt.root(), empty_control_smt.root(), "SMT root after deletion mismatch");
+    assert_eq!(smt.get_value(&key), EMPTY_WORD, "get_value after deletion failed");
+    assert_eq!(smt.entries().count(), 0, "SMT should have no entries after deletion");
+}
+
+pub fn duplicate_key_insertion<S: SmtStorage>(storage: S) {
+    let key = RpoDigest::from([ONE, ONE, ONE, ONE]);
+    let value1 = [ONE; WORD_SIZE];
+    let value2 = [2_u32.into(); WORD_SIZE];
+
+    let entries = vec![(key, value1), (key, value2)];
+
+    let result = LargeSmt::<S>::with_entries(storage, entries);
+    assert!(result.is_err(), "Expected an error when inserting duplicate keys");
+}
+
+pub fn delete_entry<S: SmtStorage>(storage: S) {
+    let key1 = RpoDigest::from([ONE, ONE, ONE, ONE]);
+    let value1 = [ONE; WORD_SIZE];
+    let key2 = RpoDigest::from([2_u32, 2_u32, 2_u32, 2_u32]);
+    let value2 = [2_u32.into(); WORD_SIZE];
+    let key3 = RpoDigest::from([3_u32, 3_u32, 3_u32, 3_u32]);
+    let value3 = [3_u32.into(); WORD_SIZE];
+
+    let initial_entries = vec![(key1, value1), (key2, value2), (key3, value3)];
+
+    let mut smt = LargeSmt::<S>::with_entries(storage, initial_entries.clone()).unwrap();
+
+    // "Delete" key2 by updating its value to EMPTY_WORD
+    let mutations = smt.compute_mutations(vec![(key2, EMPTY_WORD)]);
+    smt.apply_mutations(mutations).unwrap();
+
+    // Check that key2 now returns EMPTY_WORD
+    assert_eq!(
+        smt.get_value(&key2),
+        EMPTY_WORD,
+        "get_value for deleted key should be EMPTY_WORD"
+    );
+
+    // Check that key2 is not in entries()
+    let current_entries: Vec<_> = smt.entries().collect();
+    assert!(
+        !current_entries.iter().any(|(k, _v)| k == &key2),
+        "Deleted key should not be in entries"
+    );
+    assert_eq!(current_entries.len(), 2, "SMT should have 2 entries after deletion");
+
+    // Check that other keys are still present
+    assert_eq!(smt.get_value(&key1), value1, "Value for key1 changed after deleting key2");
+    assert_eq!(smt.get_value(&key3), value3, "Value for key3 changed after deleting key2");
+
+    // Verify the root hash against a control SMT with the remaining entries
+    let remaining_entries = vec![(key1, value1), (key3, value3)];
+    let control_smt_after_delete = Smt::with_entries(remaining_entries).unwrap();
+    assert_eq!(smt.root(), control_smt_after_delete.root(), "SMT root mismatch after deletion");
+}
+
+pub fn insert_entry<S: SmtStorage>(storage: S) {
+    let initial_entries = generate_entries(100);
+
+    let mut large_smt = LargeSmt::<S>::with_entries(storage, initial_entries.clone()).unwrap();
+    let mut control_smt = Smt::with_entries(initial_entries.clone()).unwrap();
+
+    assert_eq!(large_smt.num_entries(), control_smt.num_entries(), "Number of entries mismatch");
+    assert_eq!(large_smt.num_leaves(), control_smt.num_leaves(), "Number of leaves mismatch");
+
+    // Generate new key that wasn't in the initial construction
+    let new_key = RpoDigest::from([100_u32, 100_u32, 100_u32, 100_u32]);
+    let new_value = [100_u32.into(); WORD_SIZE];
+
+    let old_value = large_smt.insert(new_key, new_value);
+    let control_old_value = control_smt.insert(new_key, new_value);
+    assert_eq!(old_value, control_old_value, "Old values mismatch");
+    assert_eq!(old_value, EMPTY_WORD, "Expected empty value");
+
+    assert_eq!(large_smt.num_entries(), control_smt.num_entries(), "Number of entries mismatch");
+    assert_eq!(large_smt.num_leaves(), control_smt.num_leaves(), "Number of leaves mismatch");
+
+    // Verify the value was inserted
+    assert_eq!(large_smt.get_value(&new_key), new_value, "Value mismatch");
+    assert_eq!(control_smt.get_value(&new_key), new_value, "Value mismatch");
+
+    // Verify roots match
+    assert_eq!(large_smt.root(), control_smt.root(), "Roots don't match after insert");
+
+    // Try to open a proof for the inserted key
+    let large_proof = large_smt.open(&new_key);
+    let control_proof = control_smt.open(&new_key);
+    assert_eq!(large_proof, control_proof, "Proofs don't match");
+
+    // Verify we can still open proofs for the original keys
+    for (key, _) in initial_entries {
+        let large_proof = large_smt.open(&key);
+        let control_proof = control_smt.open(&key);
+        assert_eq!(large_proof, control_proof, "Proofs don't match for original key: {key:?}");
+    }
+}
+
+pub fn mutations_revert<S: SmtStorage>(storage: S) {
+    let mut smt = LargeSmt::<S>::new(storage).unwrap();
+
+    let key_1: RpoDigest = RpoDigest::from([ONE, ONE, ONE, Felt::new(1)]);
+    let key_2: RpoDigest =
+        RpoDigest::from([2_u32.into(), 2_u32.into(), 2_u32.into(), Felt::new(2)]);
+    let key_3: RpoDigest =
+        RpoDigest::from([0_u32.into(), 0_u32.into(), 0_u32.into(), Felt::new(3)]);
+
+    let value_1 = [ONE; WORD_SIZE];
+    let value_2 = [2_u32.into(); WORD_SIZE];
+    let value_3 = [3_u32.into(); WORD_SIZE];
+
+    smt.insert(key_1, value_1);
+    smt.insert(key_2, value_2);
+
+    let mutations =
+        smt.compute_mutations(vec![(key_1, EMPTY_WORD), (key_2, value_1), (key_3, value_3)]);
+
+    let original_root = smt.root();
+    let revert = smt.apply_mutations_with_reversion(mutations).unwrap();
+    assert_eq!(revert.old_root, smt.root(), "reverse mutations old root did not match");
+    assert_eq!(revert.root(), original_root, "reverse mutations new root did not match");
+
+    smt.apply_mutations(revert).unwrap();
+
+    assert_eq!(smt.root(), original_root, "SMT with applied revert mutations did not match original SMT");
+}

--- a/miden-crypto/src/merkle/smt/full/large/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/large/tests.rs
@@ -19,13 +19,16 @@ fn generate_entries(pair_count: u64) -> Vec<(RpoDigest, Word)> {
 /// Tests that `get_value()` works as expected
 #[test]
 fn test_smt_get_value() {
+    use std::path::Path;
+    let path = Path::new("test_smt");
+
     let key_1: RpoDigest = RpoDigest::from([ONE, ONE, ONE, ONE]);
     let key_2: RpoDigest = RpoDigest::from([2_u32, 2_u32, 2_u32, 2_u32]);
 
     let value_1 = [ONE; WORD_SIZE];
     let value_2 = [2_u32.into(); WORD_SIZE];
 
-    let smt = LargeSmt::with_entries([(key_1, value_1), (key_2, value_2)]).unwrap();
+    let smt = LargeSmt::with_entries(path, [(key_1, value_1), (key_2, value_2)]).unwrap();
 
     let returned_value_1 = smt.get_value(&key_1);
     let returned_value_2 = smt.get_value(&key_2);
@@ -41,8 +44,12 @@ fn test_smt_get_value() {
 
 #[test]
 fn test_smt_and_large_smt_are_equivalent() {
+    use std::path::Path;
+
     let entries = generate_entries(1000);
     let smt = Smt::with_entries(entries.clone()).unwrap();
-    let large_smt = LargeSmt::with_entries(entries).unwrap();
+
+    let path = Path::new("test_smt");
+    let large_smt = LargeSmt::with_entries(path, entries).unwrap();
     assert_eq!(smt.root(), large_smt.root());
 }

--- a/miden-crypto/src/merkle/smt/full/large/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/large/tests.rs
@@ -1,0 +1,48 @@
+use alloc::vec::Vec;
+
+use super::{EMPTY_WORD, LargeSmt, RpoDigest, Smt};
+use crate::{Felt, ONE, WORD_SIZE, Word};
+// LargeSMT
+// --------------------------------------------------------------------------------------------
+
+fn generate_entries(pair_count: u64) -> Vec<(RpoDigest, Word)> {
+    (0..pair_count)
+        .map(|i| {
+            let leaf_index = ((i as f64 / pair_count as f64) * (pair_count as f64)) as u64;
+            let key = RpoDigest::new([ONE, ONE, Felt::new(i), Felt::new(leaf_index)]);
+            let value = [ONE, ONE, ONE, Felt::new(i)];
+            (key, value)
+        })
+        .collect()
+}
+
+/// Tests that `get_value()` works as expected
+#[test]
+fn test_smt_get_value() {
+    let key_1: RpoDigest = RpoDigest::from([ONE, ONE, ONE, ONE]);
+    let key_2: RpoDigest = RpoDigest::from([2_u32, 2_u32, 2_u32, 2_u32]);
+
+    let value_1 = [ONE; WORD_SIZE];
+    let value_2 = [2_u32.into(); WORD_SIZE];
+
+    let smt = LargeSmt::with_entries([(key_1, value_1), (key_2, value_2)]).unwrap();
+
+    let returned_value_1 = smt.get_value(&key_1);
+    let returned_value_2 = smt.get_value(&key_2);
+
+    assert_eq!(value_1, returned_value_1);
+    assert_eq!(value_2, returned_value_2);
+
+    // Check that a key with no inserted value returns the empty word
+    let key_no_value = RpoDigest::from([42_u32, 42_u32, 42_u32, 42_u32]);
+
+    assert_eq!(EMPTY_WORD, smt.get_value(&key_no_value));
+}
+
+#[test]
+fn test_smt_and_large_smt_are_equivalent() {
+    let entries = generate_entries(1000);
+    let smt = Smt::with_entries(entries.clone()).unwrap();
+    let large_smt = LargeSmt::with_entries(entries).unwrap();
+    assert_eq!(smt.root(), large_smt.root());
+}

--- a/miden-crypto/src/merkle/smt/full/large/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/large/tests.rs
@@ -53,8 +53,13 @@ fn test_smt_and_large_smt_are_equivalent() {
     let smt = Smt::with_entries(entries.clone()).unwrap();
 
     let path = setup_db_path();
-    let large_smt = LargeSmt::with_entries(&path, entries).unwrap();
+    let large_smt = LargeSmt::with_entries(&path, entries.clone()).unwrap();
     assert_eq!(smt.root(), large_smt.root());
+
+    // check leaf openings are the same
+    for (key, value) in entries {
+        assert_eq!(smt.open(&key), large_smt.open(&key));
+    }
 }
 
 #[test]

--- a/miden-crypto/src/merkle/smt/full/large/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/large/tests.rs
@@ -1,82 +1,82 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use super::{MemoryStorage, test_details::*};
 
-use super::{EMPTY_WORD, LargeSmt, RpoDigest, Smt};
-use crate::{
-    ONE, WORD_SIZE,
-    merkle::smt::full::concurrent::{
-        COLS_PER_SUBTREE,
-        tests::{generate_entries, generate_updates},
-    },
-};
 // LargeSMT
 // --------------------------------------------------------------------------------------------
 
-fn setup_db_path() -> PathBuf {
-    let path = Path::new("test_smt");
-    if path.exists() {
-        std::fs::remove_dir_all(path).unwrap();
-    }
-    fs::create_dir_all(path).expect("Failed to create database directory");
-    path.to_path_buf()
-}
-
-/// Tests that `get_value()` works as expected
 #[test]
 fn test_smt_get_value() {
-    let key_1: RpoDigest = RpoDigest::from([ONE, ONE, ONE, ONE]);
-    let key_2: RpoDigest = RpoDigest::from([2_u32, 2_u32, 2_u32, 2_u32]);
-
-    let value_1 = [ONE; WORD_SIZE];
-    let value_2 = [2_u32.into(); WORD_SIZE];
-
-    let path = setup_db_path();
-    let smt = LargeSmt::with_entries(&path, [(key_1, value_1), (key_2, value_2)]).unwrap();
-
-    let returned_value_1 = smt.get_value(&key_1);
-    let returned_value_2 = smt.get_value(&key_2);
-
-    assert_eq!(value_1, returned_value_1);
-    assert_eq!(value_2, returned_value_2);
-
-    // Check that a key with no inserted value returns the empty word
-    let key_no_value = RpoDigest::from([42_u32, 42_u32, 42_u32, 42_u32]);
-
-    assert_eq!(EMPTY_WORD, smt.get_value(&key_no_value));
+    let storage = MemoryStorage::new();
+    smt_get_value(storage);
 }
 
 #[test]
-fn test_smt_and_large_smt_are_equivalent() {
-    let entries = generate_entries(1000);
-    let smt = Smt::with_entries(entries.clone()).unwrap();
+fn test_equivalent_roots() {
+    let storage = MemoryStorage::new();
+    equivalent_roots(storage);
+}
 
-    let path = setup_db_path();
-    let large_smt = LargeSmt::with_entries(&path, entries.clone()).unwrap();
-    assert_eq!(smt.root(), large_smt.root());
+#[test]
+fn test_equivalent_openings() {
+    let storage = MemoryStorage::new();
+    equivalent_openings(storage);
+}
 
-    // check leaf openings are the same
-    for (key, value) in entries {
-        assert_eq!(smt.open(&key), large_smt.open(&key));
-    }
+#[test]
+fn test_equivalent_entry_sets() {
+    let storage = MemoryStorage::new();
+    equivalent_entry_sets(storage);
+}
+
+#[test]
+fn test_equivalent_leaf_sets() {
+    let storage = MemoryStorage::new();
+    equivalent_leaf_sets(storage);
+}
+
+#[test]
+fn test_equivalent_inner_nodes() {
+    let storage = MemoryStorage::new();
+    equivalent_inner_nodes(storage);
 }
 
 #[test]
 fn test_compute_mutations() {
-    const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 64;
-    let entries = generate_entries(PAIR_COUNT);
+    let storage = MemoryStorage::new();
+    compute_mutations(storage);
+}
 
-    let tree = Smt::with_entries(entries.clone()).unwrap();
+#[test]
+fn test_empty_smt() {
+    let storage = MemoryStorage::new();
+    empty_smt(storage);
+}
 
-    let path = setup_db_path();
-    let large_tree = LargeSmt::with_entries(&path, entries.clone()).unwrap();
+#[test]
+fn test_single_entry_smt() {
+    let storage = MemoryStorage::new();
+    single_entry_smt(storage);
+}
 
-    let updates = generate_updates(entries, 1000);
-    let control = tree.compute_mutations(updates.clone());
-    let mutations = large_tree.compute_mutations(updates);
-    assert_eq!(mutations.root(), control.root());
-    assert_eq!(mutations.old_root(), control.old_root());
-    assert_eq!(mutations.node_mutations(), control.node_mutations());
-    assert_eq!(mutations.new_pairs(), control.new_pairs());
+#[test]
+fn test_duplicate_key_insertion() {
+    let storage = MemoryStorage::new();
+    duplicate_key_insertion(storage);
+}
+
+#[test]
+fn test_delete_entry() {
+    let storage = MemoryStorage::new();
+    delete_entry(storage);
+}
+
+#[test]
+fn test_insert_entry() {
+    let storage = MemoryStorage::new();
+    insert_entry(storage);
+}
+
+#[test]
+fn test_mutations_revert() {
+    let storage = MemoryStorage::new();
+    mutations_revert(storage);
 }

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -15,8 +15,12 @@ mod proof;
 pub use proof::SmtProof;
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
+#[cfg(feature = "concurrent")]
 mod large;
-pub use large::{LargeSmt, MemoryStorage, RocksDbStorage, SmtStorage};
+#[cfg(feature = "rocksdb")]
+pub use large::RocksDbStorage;
+#[cfg(feature = "concurrent")]
+pub use large::{LargeSmt, MemoryStorage, SmtStorage};
 
 // Concurrent implementation
 #[cfg(feature = "concurrent")]
@@ -26,6 +30,8 @@ pub use concurrent::{SubtreeLeaf, build_subtree_for_bench};
 
 #[cfg(test)]
 mod tests;
+#[cfg(feature = "internal")]
+pub use large::test_details;
 
 // CONSTANTS
 // ================================================================================================

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -16,7 +16,7 @@ pub use proof::SmtProof;
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 mod large;
-pub use large::LargeSmt;
+pub use large::{LargeSmt, MemoryStorage, RocksDbStorage, SmtStorage};
 
 // Concurrent implementation
 #[cfg(feature = "concurrent")]

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -18,7 +18,7 @@ use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError,
 #[cfg(feature = "concurrent")]
 mod large;
 #[cfg(feature = "rocksdb")]
-pub use large::RocksDbStorage;
+pub use large::{RocksDbConfig, RocksDbStorage};
 #[cfg(feature = "concurrent")]
 pub use large::{LargeSmt, MemoryStorage, SmtStorage};
 

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 mod full;
-pub use full::{SMT_DEPTH, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError};
+pub use full::{LargeSmt, SMT_DEPTH, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError};
 #[cfg(feature = "internal")]
 pub use full::{SubtreeLeaf, build_subtree_for_bench};
 

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 
 mod full;
 #[cfg(feature = "rocksdb")]
-pub use full::RocksDbStorage;
+pub use full::{RocksDbConfig, RocksDbStorage};
 #[cfg(feature = "concurrent")]
 pub use full::{LargeSmt, MemoryStorage};
 pub use full::{SMT_DEPTH, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError};

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -1,6 +1,8 @@
 use alloc::vec::Vec;
 use core::hash::Hash;
 
+#[cfg(feature = "internal")]
+pub use full::test_details;
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 use super::{EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, NodeIndex};
@@ -10,7 +12,11 @@ use crate::{
 };
 
 mod full;
-pub use full::{LargeSmt, MemoryStorage,RocksDbStorage, SMT_DEPTH, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError};
+#[cfg(feature = "rocksdb")]
+pub use full::RocksDbStorage;
+#[cfg(feature = "concurrent")]
+pub use full::{LargeSmt, MemoryStorage};
+pub use full::{SMT_DEPTH, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError};
 #[cfg(feature = "internal")]
 pub use full::{SubtreeLeaf, build_subtree_for_bench};
 

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 mod full;
-pub use full::{LargeSmt, SMT_DEPTH, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError};
+pub use full::{LargeSmt, MemoryStorage,RocksDbStorage, SMT_DEPTH, Smt, SmtLeaf, SmtLeafError, SmtProof, SmtProofError};
 #[cfg(feature = "internal")]
 pub use full::{SubtreeLeaf, build_subtree_for_bench};
 

--- a/miden-crypto/tests/rocksdb_large_smt.rs
+++ b/miden-crypto/tests/rocksdb_large_smt.rs
@@ -1,0 +1,147 @@
+use miden_crypto::merkle::{InnerNodeInfo, LargeSmt, RocksDbStorage, test_details};
+use tempfile::TempDir;
+
+fn setup_storage() -> (RocksDbStorage, TempDir) {
+    let temp_dir = tempfile::Builder::new()
+        .prefix("test_smt_rocksdb_")
+        .tempdir()
+        .expect("Failed to create temporary directory for RocksDB test");
+
+    let db_path = temp_dir.path().to_path_buf();
+
+    let storage = RocksDbStorage::open(&db_path)
+        .expect("Failed to open RocksDbStorage in temporary directory");
+    (storage, temp_dir)
+}
+
+#[test]
+fn rocksdb_test_smt_get_value() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::smt_get_value(storage);
+}
+
+#[test]
+fn rocksdb_test_equivalent_roots() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::equivalent_roots(storage);
+}
+
+#[test]
+fn rocksdb_test_equivalent_openings() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::equivalent_openings(storage);
+}
+
+#[test]
+fn rocksdb_test_equivalent_entry_sets() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::equivalent_entry_sets(storage);
+}
+
+#[test]
+fn rocksdb_test_equivalent_leaf_sets() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::equivalent_leaf_sets(storage);
+}
+
+#[test]
+fn rocksdb_test_equivalent_inner_nodes() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::equivalent_inner_nodes(storage);
+}
+
+#[test]
+fn rocksdb_test_compute_mutations() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::compute_mutations(storage);
+}
+
+#[test]
+fn rocksdb_test_empty_smt() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::empty_smt(storage);
+}
+
+#[test]
+fn rocksdb_test_single_entry_smt() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::single_entry_smt(storage);
+}
+
+#[test]
+fn rocksdb_test_duplicate_key_insertion() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::duplicate_key_insertion(storage);
+}
+
+#[test]
+fn rocksdb_test_delete_entry() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::delete_entry(storage);
+}
+
+#[test]
+fn rocksdb_test_mutations_revert() {
+    let (storage, _temp_dir) = setup_storage();
+    test_details::mutations_revert(storage);
+}
+
+#[test]
+fn rocksdb_test_reopening_smt() {
+    let entries = test_details::generate_entries(1000);
+
+    // Create SMT with a single entry
+    let (initial_storage, temp_dir_guard) = setup_storage();
+    let db_path = temp_dir_guard.path().to_path_buf();
+
+    let smt = LargeSmt::<RocksDbStorage>::with_entries(initial_storage, entries).unwrap();
+    let root = smt.root();
+
+    // collect all the inner nodes
+    let mut inner_nodes: Vec<InnerNodeInfo> = smt.inner_nodes().collect();
+    inner_nodes.sort_by_key(|info| info.value);
+    drop(smt);
+
+    // Reopen the db using the same path
+    let reopened_storage = RocksDbStorage::open(&db_path).unwrap();
+    let smt = LargeSmt::<RocksDbStorage>::new(reopened_storage).unwrap();
+
+    // again collect all the inner nodes
+    let mut inner_nodes_2: Vec<InnerNodeInfo> = smt.inner_nodes().collect();
+    inner_nodes_2.sort_by_key(|info| info.value);
+
+    // check if the inner nodes match
+    assert_eq!(inner_nodes.len(), inner_nodes_2.len());
+    assert_eq!(inner_nodes, inner_nodes_2);
+    assert_eq!(smt.root(), root);
+}
+
+#[test]
+fn rocksdb_test_reopening_smt_after_insertion() {
+    let entries = test_details::generate_entries(1000);
+
+    // Create SMT with a single entry
+    let (initial_storage, temp_dir_guard) = setup_storage();
+    let db_path = temp_dir_guard.path().to_path_buf();
+
+    let smt = LargeSmt::<RocksDbStorage>::with_entries(initial_storage, entries).unwrap();
+    let root = smt.root();
+
+    // collect all the inner nodes
+    let mut inner_nodes: Vec<InnerNodeInfo> = smt.inner_nodes().collect();
+    inner_nodes.sort_by_key(|info| info.value);
+    drop(smt);
+
+    // Reopen the db using the same path
+    let reopened_storage = RocksDbStorage::open(&db_path).unwrap();
+    let smt = LargeSmt::<RocksDbStorage>::new(reopened_storage).unwrap();
+
+    // again collect all the inner nodes
+    let mut inner_nodes_2: Vec<InnerNodeInfo> = smt.inner_nodes().collect();
+    inner_nodes_2.sort_by_key(|info| info.value);
+
+    // check if the inner nodes match
+    assert_eq!(inner_nodes.len(), inner_nodes_2.len());
+    assert_eq!(inner_nodes, inner_nodes_2);
+    assert_eq!(smt.root(), root);
+}

--- a/miden-crypto/tests/rocksdb_large_smt.rs
+++ b/miden-crypto/tests/rocksdb_large_smt.rs
@@ -1,4 +1,5 @@
-use miden_crypto::merkle::{InnerNodeInfo, LargeSmt, RocksDbStorage, test_details};
+use miden_crypto::merkle::test_details;
+use miden_crypto::merkle::{InnerNodeInfo, LargeSmt, RocksDbConfig, RocksDbStorage};
 use tempfile::TempDir;
 
 fn setup_storage() -> (RocksDbStorage, TempDir) {
@@ -9,7 +10,7 @@ fn setup_storage() -> (RocksDbStorage, TempDir) {
 
     let db_path = temp_dir.path().to_path_buf();
 
-    let storage = RocksDbStorage::open(&db_path)
+    let storage = RocksDbStorage::open(RocksDbConfig::new(db_path))
         .expect("Failed to open RocksDbStorage in temporary directory");
     (storage, temp_dir)
 }
@@ -103,7 +104,7 @@ fn rocksdb_test_reopening_smt() {
     drop(smt);
 
     // Reopen the db using the same path
-    let reopened_storage = RocksDbStorage::open(&db_path).unwrap();
+    let reopened_storage = RocksDbStorage::open(RocksDbConfig::new(db_path)).unwrap();
     let smt = LargeSmt::<RocksDbStorage>::new(reopened_storage).unwrap();
 
     // again collect all the inner nodes
@@ -133,7 +134,7 @@ fn rocksdb_test_reopening_smt_after_insertion() {
     drop(smt);
 
     // Reopen the db using the same path
-    let reopened_storage = RocksDbStorage::open(&db_path).unwrap();
+    let reopened_storage = RocksDbStorage::open(RocksDbConfig::new(db_path)).unwrap();
     let smt = LargeSmt::<RocksDbStorage>::new(reopened_storage).unwrap();
 
     // again collect all the inner nodes


### PR DESCRIPTION
WIP: Large-scale Smt Implementation

This PR introduces an **early-stage prototype** of `LargeSmt`, an Smt implementation with hybrid storage layout:
- top 24 levels of the tree are  in memory
- all lower-level inner nodes and leaves are persisted using LMDB, via the [heed](https://docs.rs/heed) wrapper crate.
- concurrent subtree construction is supported using rayon, enabling efficient parallel initialization from large entry sets.
- default storage path: `large_smt.db` (configurable later).

⚠️ This is the first prototype using `heed` + `LMDB`. Other storage backends may be explored depending on performance. Some of the functionality is still stubbed.

⚠️ No performance optimizations have been applied yet -  this is a baseline implementation to validate architectural direction and initial behavior.

⚠️ Several methods are currently stubbed or partially implemented, including iteration and mutation-related APIs. These will be completed in follow-up commits.