### PR TITLE
fix: enforce missing_docs lint at crate level

### DIFF
--- a/miden-crypto/src/lib.rs
+++ b/miden-crypto/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(missing_docs)]
 
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
## Describe your changes
Closes #255 
This PR adds `#![deny(missing_docs)]` at the crate level in `lib.rs` to enforce documentation for all public items. This will help ensure that missing documentation is caught during compilation, improving the overall maintainability and usability of the crate.

!!! By doing so, the compiler will raise errors whenever public items lack proper documentation.

However, since the current codebase contains many undocumented public items, running cargo build or cargo test now results in numerous errors.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
