### PR TITLE
Add default constructors to MmrPeaks and PartialMmr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.15.0 (TBD)
 
+- Added `empty()` constructors to `MmrPeaks` and `PartialMmr` (#409).
 
 ## 0.14.0 (2025-03-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.15.0 (TBD)
 
-- Added `empty()` constructors to `MmrPeaks` and `PartialMmr` (#409).
+- Added default constructors to `MmrPeaks` and `PartialMmr` (#409).
 
 ## 0.14.0 (2025-03-15)
 

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -84,6 +84,16 @@ impl PartialMmr {
         Self { forest, peaks, nodes, track_latest }
     }
 
+    /// Returns a new [`PartialMmr`] instantiated with empty peaks and nodes and 0 leaves.
+    pub const fn empty() -> Self {
+        let forest = 0;
+        let peaks = Vec::new();
+        let nodes = BTreeMap::new();
+        let track_latest = false;
+
+        Self { forest, peaks, nodes, track_latest }
+    }
+
     /// Returns a new [PartialMmr] instantiated from the specified components.
     ///
     /// This constructor does not check the consistency between peaks and nodes. If the specified

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -70,6 +70,18 @@ pub struct PartialMmr {
     pub(crate) track_latest: bool,
 }
 
+impl Default for PartialMmr {
+    /// Creates a new [PartialMmr] with default values.
+    fn default() -> Self {
+        let forest = 0;
+        let peaks = Vec::new();
+        let nodes = BTreeMap::new();
+        let track_latest = false;
+
+        Self { forest, peaks, nodes, track_latest }
+    }
+}
+
 impl PartialMmr {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
@@ -78,16 +90,6 @@ impl PartialMmr {
     pub fn from_peaks(peaks: MmrPeaks) -> Self {
         let forest = peaks.num_leaves();
         let peaks = peaks.into();
-        let nodes = BTreeMap::new();
-        let track_latest = false;
-
-        Self { forest, peaks, nodes, track_latest }
-    }
-
-    /// Returns a new [`PartialMmr`] instantiated with empty peaks and nodes and 0 leaves.
-    pub const fn empty() -> Self {
-        let forest = 0;
-        let peaks = Vec::new();
         let nodes = BTreeMap::new();
         let track_latest = false;
 

--- a/miden-crypto/src/merkle/mmr/peaks.rs
+++ b/miden-crypto/src/merkle/mmr/peaks.rs
@@ -55,6 +55,11 @@ impl MmrPeaks {
         Ok(Self { num_leaves, peaks })
     }
 
+    /// Returns new [`MmrPeaks`] instantiated from an empty vector of peaks and 0 leaves.
+    pub const fn empty() -> Self {
+        Self { num_leaves: 0, peaks: Vec::new() }
+    }
+
     // ACCESSORS
     // --------------------------------------------------------------------------------------------
 

--- a/miden-crypto/src/merkle/mmr/peaks.rs
+++ b/miden-crypto/src/merkle/mmr/peaks.rs
@@ -34,6 +34,13 @@ pub struct MmrPeaks {
     peaks: Vec<RpoDigest>,
 }
 
+impl Default for MmrPeaks {
+    /// Returns new [`MmrPeaks`] instantiated from an empty vector of peaks and 0 leaves.
+    fn default() -> Self {
+        Self { num_leaves: 0, peaks: Vec::new() }
+    }
+}
+
 impl MmrPeaks {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -53,11 +60,6 @@ impl MmrPeaks {
         }
 
         Ok(Self { num_leaves, peaks })
-    }
-
-    /// Returns new [`MmrPeaks`] instantiated from an empty vector of peaks and 0 leaves.
-    pub const fn empty() -> Self {
-        Self { num_leaves: 0, peaks: Vec::new() }
     }
 
     // ACCESSORS

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -13,6 +13,23 @@ use crate::{
 };
 
 #[test]
+fn tests_empty_mmr_peaks() {
+    let peaks = MmrPeaks::empty();
+    assert_eq!(peaks.num_peaks(), 0);
+    assert_eq!(peaks.num_leaves(), 0);
+}
+
+#[test]
+fn test_empty_partial_mmr() {
+    let mmr = PartialMmr::empty();
+    assert_eq!(mmr.num_leaves(), 0);
+    assert_eq!(mmr.forest(), 0);
+    assert_eq!(mmr.peaks(), MmrPeaks::empty());
+    assert!(mmr.nodes.is_empty());
+    assert!(!mmr.track_latest);
+}
+
+#[test]
 fn test_position_equal_or_higher_than_leafs_is_never_contained() {
     let empty_forest = 0;
     for pos in 1..1024 {

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -14,17 +14,17 @@ use crate::{
 
 #[test]
 fn tests_empty_mmr_peaks() {
-    let peaks = MmrPeaks::empty();
+    let peaks = MmrPeaks::default();
     assert_eq!(peaks.num_peaks(), 0);
     assert_eq!(peaks.num_leaves(), 0);
 }
 
 #[test]
 fn test_empty_partial_mmr() {
-    let mmr = PartialMmr::empty();
+    let mmr = PartialMmr::default();
     assert_eq!(mmr.num_leaves(), 0);
     assert_eq!(mmr.forest(), 0);
-    assert_eq!(mmr.peaks(), MmrPeaks::empty());
+    assert_eq!(mmr.peaks(), MmrPeaks::default());
     assert!(mmr.nodes.is_empty());
     assert!(!mmr.track_latest);
 }


### PR DESCRIPTION
Add default constructors to MmrPeaks and PartialMmr and unit tests.

