### PR TITLE
docs: update old GitHub and GitHub Pages URLs to new 0xMiden naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@
 
 We want to make contributing to this project as easy and transparent as possible, whether it's:
 
-- Reporting a [bug](https://github.com/0xPolygonMiden/crypto/issues/new)
-- Taking part in [discussions](https://github.com/0xPolygonMiden/crypto/discussions)
-- Submitting a [fix](https://github.com/0xPolygonMiden/crypto/pulls)
-- Proposing new [features](https://github.com/0xPolygonMiden/crypto/issues/new)
+- Reporting a [bug](https://github.com/0xMiden/crypto/issues/new)
+- Taking part in [discussions](https://github.com/0xMiden/crypto/discussions)
+- Submitting a [fix](https://github.com/0xMiden/crypto/pulls)
+- Proposing new [features](https://github.com/0xMiden/crypto/issues/new)
 
 &nbsp;
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "3"  # Use the edition 2024 dependency resolver
 [workspace.package]
 authors = ["miden contributors"]
 license = "MIT"
-repository = "https://github.com/0xPolygonMiden/crypto"
+repository = "https://github.com/0xMiden/crypto"
 categories = ["cryptography", "no-std"]
 keywords = ["miden", "crypto", "hash", "merkle"]
 edition = "2024"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Polygon Miden
+Copyright (c) 2025 Miden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Miden Crypto
 
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xPolygonMiden/crypto/blob/main/LICENSE)
-[![test](https://github.com/0xPolygonMiden/crypto/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/crypto/actions/workflows/test.yml)
-[![build](https://github.com/0xPolygonMiden/crypto/actions/workflows/build.yml/badge.svg)](https://github.com/0xPolygonMiden/crypto/actions/workflows/build.yml)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/crypto/blob/main/LICENSE)
+[![test](https://github.com/0xMiden/crypto/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/crypto/actions/workflows/test.yml)
+[![build](https://github.com/0xMiden/crypto/actions/workflows/build.yml/badge.svg)](https://github.com/0xMiden/crypto/actions/workflows/build.yml)
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.85+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![CRATE](https://img.shields.io/crates/v/miden-crypto)](https://crates.io/crates/miden-crypto)
 
-This crate contains cryptographic primitives used in Polygon Miden.
+This crate contains cryptographic primitives used in Miden.
 
 ## Hash
 

--- a/miden-crypto/src/lib.rs
+++ b/miden-crypto/src/lib.rs
@@ -53,7 +53,7 @@ fn debug_assert_is_checked() {
     // downstream.
     //
     // for reference, check
-    // https://github.com/0xPolygonMiden/miden-vm/issues/433
+    // https://github.com/0xMiden/miden-vm/issues/433
     debug_assert!(false);
 }
 


### PR DESCRIPTION
## Describe your changes
This PR updates outdated URLs across all Markdown files to reflect the repository renaming from `0xPolygonMiden` to `0xMiden`.  
It also updates GitHub Pages links from `0xpolygonmiden.github.io` to `0xmiden.github.io`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
