### PR TITLE
Run doctests in CI, and fix existing broken doctest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,18 @@ jobs:
         run: |
           rustup update --no-self-update ${{matrix.toolchain}}
           make test-smt-concurrent
+
+  doc-tests:
+    name: doc-tests
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'next') }}
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@main
+      - uses: Swatinem/rust-cache@v2
+      - name: Run doc-tests
+        run: |
+          rustup update --no-self-update
+          make test-docs
+

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,12 @@ test-no-std: ## Run tests with `no-default-features` (std)
 test-smt-concurrent: ## Run only concurrent SMT tests
 	$(DEBUG_OVERFLOW_INFO) cargo nextest run --profile smt-concurrent --release --all-features
 
+.PHONY: test-docs
+test-docs:
+	$(DEBUG_OVERFLOW_INFO) cargo test --doc --all-features
+
 .PHONY: test
-test: test-default test-smt-hashmaps test-no-std ## Run all tests except concurrent SMT tests
+test: test-default test-smt-hashmaps test-no-std test-docs ## Run all tests except concurrent SMT tests
 
 # --- checking ------------------------------------------------------------------------------------
 

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -42,7 +42,7 @@ pub struct StoreNode {
 /// # use miden_crypto::merkle::{NodeIndex, MerkleStore, MerkleTree};
 /// # use miden_crypto::hash::rpo::Rpo256;
 /// # const fn int_to_node(value: u64) -> Word {
-/// #     [Felt::new(value), ZERO, ZERO, ZERO]
+/// #     Word::new([Felt::new(value), ZERO, ZERO, ZERO])
 /// # }
 /// # let A = int_to_node(1);
 /// # let B = int_to_node(2);


### PR DESCRIPTION
This fixes the `MerkleStore` doctest broken in #411, and enables doctests in the Makefile test targets so doctest breakages are caught by CI in the future.

Fixes #421. 


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
