### PR TITLE
fix(ci): Correct arguments for changelog check script

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,5 +19,5 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
-        run: ./scripts/check-changelog.sh "${{ inputs.changelog }}"
+        run: ./scripts/check-changelog.sh
         shell: bash


### PR DESCRIPTION
## Describe your changes


The changelog workflow has an error about the  incorrect attempt to access `inputs.changelog`, which is not available in the `pull_request` event
     context. 

This change removes the invalid argument, allowing the script to use its default behavior of checking the `CHANGELOG.md` file.



## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
