### PR TITLE
chore: Replace conversions from references with moves

### DIFF
--- a/miden-crypto/benches/store.rs
+++ b/miden-crypto/benches/store.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use miden_crypto::{
     Felt, Word,
-    merkle::{LeafIndex, MerkleStore, MerkleTree, NodeIndex, SMT_MAX_DEPTH, SimpleSmt},
+    merkle::{IntoMerkleStore, LeafIndex, MerkleTree, NodeIndex, SMT_MAX_DEPTH, SimpleSmt},
 };
 use rand_utils::{rand_array, rand_value};
 
@@ -32,7 +32,7 @@ fn get_empty_leaf_simplesmt(c: &mut Criterion) {
     // both SMT and the store are pre-populated with empty hashes, accessing these values is what is
     // being benchmarked here, so no values are inserted into the backends
     let smt = SimpleSmt::<DEPTH>::new().unwrap();
-    let store = MerkleStore::from(&smt);
+    let store = smt.to_merkle_store();
     let root = smt.root();
 
     group.bench_function(BenchmarkId::new("SimpleSmt", DEPTH), |b| {
@@ -63,7 +63,7 @@ fn get_leaf_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(&mtree);
+        let store = mtree.to_merkle_store();
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -102,7 +102,7 @@ fn get_leaf_simplesmt(c: &mut Criterion) {
             .map(|(c, &v)| (c.try_into().unwrap(), v))
             .collect::<Vec<(u64, Word)>>();
         let smt = SimpleSmt::<SMT_MAX_DEPTH>::with_leaves(smt_leaves.clone()).unwrap();
-        let store = MerkleStore::from(&smt);
+        let store = smt.to_merkle_store();
         let root = smt.root();
         let size_u64 = size as u64;
 
@@ -134,7 +134,7 @@ fn get_node_of_empty_simplesmt(c: &mut Criterion) {
     // of these values is what is being benchmarked here, so no values are inserted into the
     // backends.
     let smt = SimpleSmt::<DEPTH>::new().unwrap();
-    let store = MerkleStore::from(&smt);
+    let store = smt.to_merkle_store();
     let root = smt.root();
     let half_depth = DEPTH / 2;
     let half_size = 2_u64.pow(half_depth as u32);
@@ -168,7 +168,7 @@ fn get_node_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(&mtree);
+        let store = mtree.to_merkle_store();
         let root = mtree.root();
         let half_depth = mtree.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -208,7 +208,7 @@ fn get_node_simplesmt(c: &mut Criterion) {
             .map(|(c, &v)| (c.try_into().unwrap(), v))
             .collect::<Vec<(u64, Word)>>();
         let smt = SimpleSmt::<SMT_MAX_DEPTH>::with_leaves(smt_leaves.clone()).unwrap();
-        let store = MerkleStore::from(&smt);
+        let store = smt.to_merkle_store();
         let root = smt.root();
         let half_depth = SMT_MAX_DEPTH / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -242,7 +242,7 @@ fn get_leaf_path_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(&mtree);
+        let store = mtree.to_merkle_store();
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -281,7 +281,7 @@ fn get_leaf_path_simplesmt(c: &mut Criterion) {
             .map(|(c, &v)| (c.try_into().unwrap(), v))
             .collect::<Vec<(u64, Word)>>();
         let smt = SimpleSmt::<SMT_MAX_DEPTH>::with_leaves(smt_leaves.clone()).unwrap();
-        let store = MerkleStore::from(&smt);
+        let store = smt.to_merkle_store();
         let root = smt.root();
         let size_u64 = size as u64;
 
@@ -328,7 +328,7 @@ fn new(c: &mut Criterion) {
                 || leaves,
                 |l| {
                     let mtree = MerkleTree::new(l).unwrap();
-                    black_box(MerkleStore::from(&mtree));
+                    black_box(mtree.to_merkle_store());
                 },
                 BatchSize::SmallInput,
             )
@@ -359,7 +359,7 @@ fn new(c: &mut Criterion) {
                 },
                 |l| {
                     let smt = SimpleSmt::<SMT_MAX_DEPTH>::with_leaves(l).unwrap();
-                    black_box(MerkleStore::from(&smt));
+                    black_box(smt.to_merkle_store());
                 },
                 BatchSize::SmallInput,
             )
@@ -378,7 +378,7 @@ fn update_leaf_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mut mtree = MerkleTree::new(leaves).unwrap();
-        let mut store = MerkleStore::from(&mtree);
+        let mut store = mtree.to_merkle_store();
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -424,7 +424,7 @@ fn update_leaf_simplesmt(c: &mut Criterion) {
             .map(|(c, &v)| (c.try_into().unwrap(), v))
             .collect::<Vec<(u64, Word)>>();
         let mut smt = SimpleSmt::<SMT_MAX_DEPTH>::with_leaves(smt_leaves.clone()).unwrap();
-        let mut store = MerkleStore::from(&smt);
+        let mut store = smt.to_merkle_store();
         let root = smt.root();
         let size_u64 = size as u64;
 

--- a/miden-crypto/benches/store.rs
+++ b/miden-crypto/benches/store.rs
@@ -63,7 +63,7 @@ fn get_leaf_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(mtree.clone());
+        let store = MerkleStore::from(&mtree);
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -168,7 +168,7 @@ fn get_node_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(mtree.clone());
+        let store = MerkleStore::from(&mtree);
         let root = mtree.root();
         let half_depth = mtree.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -242,7 +242,7 @@ fn get_leaf_path_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(mtree.clone());
+        let store = MerkleStore::from(&mtree);
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -328,7 +328,7 @@ fn new(c: &mut Criterion) {
                 || leaves,
                 |l| {
                     let mtree = MerkleTree::new(l).unwrap();
-                    black_box(MerkleStore::from(mtree));
+                    black_box(MerkleStore::from(&mtree));
                 },
                 BatchSize::SmallInput,
             )
@@ -378,7 +378,7 @@ fn update_leaf_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mut mtree = MerkleTree::new(leaves).unwrap();
-        let mut store = MerkleStore::from(mtree.clone());
+        let mut store = MerkleStore::from(&mtree);
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;

--- a/miden-crypto/benches/store.rs
+++ b/miden-crypto/benches/store.rs
@@ -63,7 +63,7 @@ fn get_leaf_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(&mtree);
+        let store = MerkleStore::from(mtree.clone());
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -168,7 +168,7 @@ fn get_node_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(&mtree);
+        let store = MerkleStore::from(mtree.clone());
         let root = mtree.root();
         let half_depth = mtree.depth() / 2;
         let half_size = 2_u64.pow(half_depth as u32);
@@ -242,7 +242,7 @@ fn get_leaf_path_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mtree = MerkleTree::new(leaves).unwrap();
-        let store = MerkleStore::from(&mtree);
+        let store = MerkleStore::from(mtree.clone());
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;
@@ -328,7 +328,7 @@ fn new(c: &mut Criterion) {
                 || leaves,
                 |l| {
                     let mtree = MerkleTree::new(l).unwrap();
-                    black_box(MerkleStore::from(&mtree));
+                    black_box(MerkleStore::from(mtree));
                 },
                 BatchSize::SmallInput,
             )
@@ -378,7 +378,7 @@ fn update_leaf_merkletree(c: &mut Criterion) {
         let leaves = &random_data[..size];
 
         let mut mtree = MerkleTree::new(leaves).unwrap();
-        let mut store = MerkleStore::from(&mtree);
+        let mut store = MerkleStore::from(mtree.clone());
         let depth = mtree.depth();
         let root = mtree.root();
         let size_u64 = size as u64;

--- a/miden-crypto/src/merkle/merkle_tree.rs
+++ b/miden-crypto/src/merkle/merkle_tree.rs
@@ -116,6 +116,16 @@ impl MerkleTree {
         self.nodes.iter().skip(leaves_start).enumerate().map(|(i, v)| (i as u64, v))
     }
 
+    /// Returns n iterator over every inner node of this [MerkleTree].
+    ///
+    /// The iterator order is unspecified.
+    pub fn inner_nodes(&self) -> InnerNodeIterator<'_> {
+        InnerNodeIterator {
+            nodes: &self.nodes,
+            index: 1, // index 0 is just padding, start at 1
+        }
+    }
+
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 
@@ -156,18 +166,6 @@ impl MerkleTree {
     }
 }
 
-impl IntoIterator for MerkleTree {
-    type Item = InnerNodeInfo;
-    type IntoIter = InnerNodeIterator;
-
-    fn into_iter(self) -> Self::IntoIter {
-        InnerNodeIterator {
-            nodes: self.nodes,
-            index: 1, // index 0 is just padding, start at 1
-        }
-    }
-}
-
 // CONVERSIONS
 // ================================================================================================
 
@@ -185,12 +183,12 @@ impl TryFrom<&[Word]> for MerkleTree {
 /// An iterator over every inner node of the [MerkleTree].
 ///
 /// Use this to extract the data of the tree, there is no guarantee on the order of the elements.
-pub struct InnerNodeIterator {
-    nodes: Vec<Word>,
+pub struct InnerNodeIterator<'a> {
+    nodes: &'a Vec<Word>,
     index: usize,
 }
 
-impl Iterator for InnerNodeIterator {
+impl Iterator for InnerNodeIterator<'_> {
     type Item = InnerNodeInfo;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -375,7 +373,7 @@ mod tests {
         let l2n2 = tree.get_node(NodeIndex::make(2, 2))?;
         let l2n3 = tree.get_node(NodeIndex::make(2, 3))?;
 
-        let nodes: Vec<InnerNodeInfo> = tree.into_iter().collect();
+        let nodes: Vec<InnerNodeInfo> = tree.inner_nodes().collect();
         let expected = vec![
             InnerNodeInfo { value: root, left: l1n0, right: l1n1 },
             InnerNodeInfo { value: l1n0, left: l2n0, right: l2n1 },

--- a/miden-crypto/src/merkle/merkle_tree.rs
+++ b/miden-crypto/src/merkle/merkle_tree.rs
@@ -1,7 +1,7 @@
 use alloc::{string::String, vec::Vec};
 use core::{fmt, slice};
 
-use super::{InnerNodeInfo, MerkleError, MerklePath, NodeIndex, Rpo256, Word};
+use super::{InnerNodeInfo, InnerNodeIterable, MerkleError, MerklePath, NodeIndex, Rpo256, Word};
 use crate::utils::{uninit_vector, word_to_hex};
 
 // MERKLE TREE
@@ -116,16 +116,6 @@ impl MerkleTree {
         self.nodes.iter().skip(leaves_start).enumerate().map(|(i, v)| (i as u64, v))
     }
 
-    /// Returns n iterator over every inner node of this [MerkleTree].
-    ///
-    /// The iterator order is unspecified.
-    pub fn inner_nodes(&self) -> InnerNodeIterator<'_> {
-        InnerNodeIterator {
-            nodes: &self.nodes,
-            index: 1, // index 0 is just padding, start at 1
-        }
-    }
-
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 
@@ -206,6 +196,18 @@ impl Iterator for InnerNodeIterator<'_> {
             })
         } else {
             None
+        }
+    }
+}
+
+impl InnerNodeIterable for MerkleTree {
+    /// Returns n iterator over every inner node of this [MerkleTree].
+    ///
+    /// The iterator order is unspecified.
+    fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
+        InnerNodeIterator {
+            nodes: &self.nodes,
+            index: 1, // Index 0 is just padding, start at 1.
         }
     }
 }

--- a/miden-crypto/src/merkle/merkle_tree.rs
+++ b/miden-crypto/src/merkle/merkle_tree.rs
@@ -116,16 +116,6 @@ impl MerkleTree {
         self.nodes.iter().skip(leaves_start).enumerate().map(|(i, v)| (i as u64, v))
     }
 
-    /// Returns n iterator over every inner node of this [MerkleTree].
-    ///
-    /// The iterator order is unspecified.
-    pub fn inner_nodes(&self) -> InnerNodeIterator<'_> {
-        InnerNodeIterator {
-            nodes: &self.nodes,
-            index: 1, // index 0 is just padding, start at 1
-        }
-    }
-
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 
@@ -166,6 +156,18 @@ impl MerkleTree {
     }
 }
 
+impl IntoIterator for MerkleTree {
+    type Item = InnerNodeInfo;
+    type IntoIter = InnerNodeIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        InnerNodeIterator {
+            nodes: self.nodes,
+            index: 1, // index 0 is just padding, start at 1
+        }
+    }
+}
+
 // CONVERSIONS
 // ================================================================================================
 
@@ -183,12 +185,12 @@ impl TryFrom<&[Word]> for MerkleTree {
 /// An iterator over every inner node of the [MerkleTree].
 ///
 /// Use this to extract the data of the tree, there is no guarantee on the order of the elements.
-pub struct InnerNodeIterator<'a> {
-    nodes: &'a Vec<Word>,
+pub struct InnerNodeIterator {
+    nodes: Vec<Word>,
     index: usize,
 }
 
-impl Iterator for InnerNodeIterator<'_> {
+impl Iterator for InnerNodeIterator {
     type Item = InnerNodeInfo;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -373,7 +375,7 @@ mod tests {
         let l2n2 = tree.get_node(NodeIndex::make(2, 2))?;
         let l2n3 = tree.get_node(NodeIndex::make(2, 3))?;
 
-        let nodes: Vec<InnerNodeInfo> = tree.inner_nodes().collect();
+        let nodes: Vec<InnerNodeInfo> = tree.into_iter().collect();
         let expected = vec![
             InnerNodeInfo { value: root, left: l1n0, right: l1n1 },
             InnerNodeInfo { value: l1n0, left: l2n0, right: l2n1 },

--- a/miden-crypto/src/merkle/merkle_tree.rs
+++ b/miden-crypto/src/merkle/merkle_tree.rs
@@ -201,7 +201,7 @@ impl Iterator for InnerNodeIterator<'_> {
 }
 
 impl InnerNodeIterable for MerkleTree {
-    /// Returns n iterator over every inner node of this [MerkleTree].
+    /// Returns an iterator over every inner node of this [`MerkleTree`].
     ///
     /// The iterator order is unspecified.
     fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -17,7 +17,10 @@ use super::{
     MmrDelta, MmrError, MmrPeaks, MmrProof,
     forest::{Forest, TreeSizeIterator},
 };
-use crate::{Word, merkle::Rpo256};
+use crate::{
+    Word,
+    merkle::{InnerNodeIterable, Rpo256},
+};
 
 // MMR
 // ===============================================================================================
@@ -247,16 +250,6 @@ impl Mmr {
         Ok(MmrDelta { forest: to_forest, data: result })
     }
 
-    /// An iterator over inner nodes in the MMR. The order of iteration is unspecified.
-    pub fn inner_nodes(&self) -> MmrNodes<'_> {
-        MmrNodes {
-            mmr: self,
-            forest: 0,
-            last_right: 0,
-            index: 0,
-        }
-    }
-
     // UTILITIES
     // ============================================================================================
 
@@ -417,6 +410,18 @@ impl Iterator for MmrNodes<'_> {
             Some(node)
         } else {
             None
+        }
+    }
+}
+
+impl InnerNodeIterable for Mmr {
+    /// An iterator over inner nodes in the MMR. The order of iteration is unspecified.
+    fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
+        MmrNodes {
+            mmr: self,
+            forest: 0,
+            last_right: 0,
+            index: 0,
         }
     }
 }

--- a/miden-crypto/src/merkle/mmr/partial.rs
+++ b/miden-crypto/src/merkle/mmr/partial.rs
@@ -734,8 +734,8 @@ mod tests {
         assert_eq!(partial_mmr.inner_nodes([].iter().cloned()).next(), None);
 
         // build Merkle store from authentication paths in partial MMR
-        let mut store: MerkleStore = MerkleStore::new();
-        store.extend(partial_mmr.inner_nodes([(1, node1)].iter().cloned()));
+        let mut store: MerkleStore =
+            partial_mmr.inner_nodes([(1, node1)].iter().cloned()).collect();
 
         let index1 = NodeIndex::new(2, 1).unwrap();
         let path1 = store.get_path(first_peak, index1).unwrap().path;
@@ -791,8 +791,8 @@ mod tests {
         partial_mmr.track(5, node5, &proof5.merkle_path).unwrap();
 
         // build Merkle store from authentication paths in partial MMR
-        let mut store: MerkleStore = MerkleStore::new();
-        store.extend(partial_mmr.inner_nodes([(1, node1), (5, node5)].iter().cloned()));
+        let store: MerkleStore =
+            partial_mmr.inner_nodes([(1, node1), (5, node5)].iter().cloned()).collect();
 
         let index1 = NodeIndex::new(2, 1).unwrap();
         let index5 = NodeIndex::new(1, 1).unwrap();

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     Felt,
     merkle::{
-        InOrderIndex, MerklePath, MerkleTree, MmrProof, NodeIndex, int_to_node,
+        InOrderIndex, InnerNodeIterable, MerklePath, MerkleTree, MmrProof, NodeIndex, int_to_node,
         mmr::forest::{Forest, TreeSizeIterator, high_bitmask},
     },
 };

--- a/miden-crypto/src/merkle/mod.rs
+++ b/miden-crypto/src/merkle/mod.rs
@@ -36,7 +36,7 @@ mod store;
 pub use store::{MerkleStore, StoreNode};
 
 mod node;
-pub use node::InnerNodeInfo;
+pub use node::{InnerNodeInfo, InnerNodeIterable};
 
 mod partial_mt;
 pub use partial_mt::PartialMerkleTree;

--- a/miden-crypto/src/merkle/mod.rs
+++ b/miden-crypto/src/merkle/mod.rs
@@ -36,7 +36,7 @@ mod store;
 pub use store::{MerkleStore, StoreNode};
 
 mod node;
-pub use node::{InnerNodeInfo, InnerNodeIterable};
+pub use node::{InnerNodeInfo, InnerNodeIterable, IntoMerkleStore};
 
 mod partial_mt;
 pub use partial_mt::PartialMerkleTree;

--- a/miden-crypto/src/merkle/node.rs
+++ b/miden-crypto/src/merkle/node.rs
@@ -9,3 +9,9 @@ pub struct InnerNodeInfo {
     pub left: Word,
     pub right: Word,
 }
+
+/// A trait for structures that can provide an iterator over their inner nodes.
+pub trait InnerNodeIterable {
+    /// Returns an iterator over the inner nodes by borrowing the structure.
+    fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo>;
+}

--- a/miden-crypto/src/merkle/node.rs
+++ b/miden-crypto/src/merkle/node.rs
@@ -1,4 +1,4 @@
-use super::Word;
+use super::{MerkleStore, Word};
 
 /// Representation of a node with two children used for iterating over containers.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,8 +10,19 @@ pub struct InnerNodeInfo {
     pub right: Word,
 }
 
-/// A trait for structures that can provide an iterator over their inner nodes.
+/// Provides an iterator over the inner nodes of a structure.
 pub trait InnerNodeIterable {
     /// Returns an iterator over the inner nodes by borrowing the structure.
     fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo>;
+}
+
+/// Produces a [`MerkleStore`] from a structure.
+pub trait IntoMerkleStore {
+    fn to_merkle_store(&self) -> MerkleStore;
+}
+
+impl<T: InnerNodeIterable> IntoMerkleStore for T {
+    fn to_merkle_store(&self) -> MerkleStore {
+        MerkleStore::from_inner_nodes(self.inner_nodes())
+    }
 }

--- a/miden-crypto/src/merkle/partial_mt/tests.rs
+++ b/miden-crypto/src/merkle/partial_mt/tests.rs
@@ -1,10 +1,10 @@
 use alloc::{collections::BTreeMap, vec::Vec};
 
 use super::{
-    super::{MerkleStore, MerkleTree, NodeIndex, PartialMerkleTree, int_to_node},
+    super::{MerkleTree, NodeIndex, PartialMerkleTree, int_to_node},
     Deserializable, InnerNodeInfo, Serializable, ValuePath, Word,
 };
-use crate::merkle::InnerNodeIterable;
+use crate::merkle::{InnerNodeIterable, IntoMerkleStore};
 
 // TEST DATA
 // ================================================================================================
@@ -94,7 +94,7 @@ fn get_root() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
     let pmt = PartialMerkleTree::with_paths([(3, path33.value, path33.path)]).unwrap();
@@ -110,7 +110,7 @@ fn add_and_get_paths() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let expected_path33 = ms.get_path(expected_root, NODE33).unwrap();
     let expected_path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -134,7 +134,7 @@ fn get_node() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -151,7 +151,7 @@ fn update_leaf() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let root = mt.root();
 
-    let mut ms = MerkleStore::from(&mt);
+    let mut ms = mt.to_merkle_store();
     let path33 = ms.get_path(root, NODE33).unwrap();
 
     let mut pmt = PartialMerkleTree::with_paths([(3, path33.value, path33.path)]).unwrap();
@@ -187,7 +187,7 @@ fn get_paths() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -234,7 +234,7 @@ fn leaves() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -300,7 +300,7 @@ fn test_inner_node_iterator() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -367,7 +367,7 @@ fn serialization() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -419,7 +419,7 @@ fn err_get_node() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -437,7 +437,7 @@ fn err_get_path() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -454,7 +454,7 @@ fn err_update_leaf() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = mt.to_merkle_store();
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 

--- a/miden-crypto/src/merkle/partial_mt/tests.rs
+++ b/miden-crypto/src/merkle/partial_mt/tests.rs
@@ -4,6 +4,7 @@ use super::{
     super::{MerkleStore, MerkleTree, NodeIndex, PartialMerkleTree, int_to_node},
     Deserializable, InnerNodeInfo, Serializable, ValuePath, Word,
 };
+use crate::merkle::InnerNodeIterable;
 
 // TEST DATA
 // ================================================================================================

--- a/miden-crypto/src/merkle/partial_mt/tests.rs
+++ b/miden-crypto/src/merkle/partial_mt/tests.rs
@@ -93,7 +93,7 @@ fn get_root() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt);
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
     let pmt = PartialMerkleTree::with_paths([(3, path33.value, path33.path)]).unwrap();
@@ -109,7 +109,7 @@ fn add_and_get_paths() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt);
 
     let expected_path33 = ms.get_path(expected_root, NODE33).unwrap();
     let expected_path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -133,7 +133,7 @@ fn get_node() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -150,7 +150,7 @@ fn update_leaf() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let root = mt.root();
 
-    let mut ms = MerkleStore::from(&mt);
+    let mut ms = MerkleStore::from(mt);
     let path33 = ms.get_path(root, NODE33).unwrap();
 
     let mut pmt = PartialMerkleTree::with_paths([(3, path33.value, path33.path)]).unwrap();
@@ -186,7 +186,7 @@ fn get_paths() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt.clone());
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -233,7 +233,7 @@ fn leaves() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt.clone());
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -299,7 +299,7 @@ fn test_inner_node_iterator() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt.clone());
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -366,7 +366,7 @@ fn serialization() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -418,7 +418,7 @@ fn err_get_node() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -436,7 +436,7 @@ fn err_get_path() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -453,7 +453,7 @@ fn err_update_leaf() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(&mt);
+    let ms = MerkleStore::from(mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 

--- a/miden-crypto/src/merkle/partial_mt/tests.rs
+++ b/miden-crypto/src/merkle/partial_mt/tests.rs
@@ -93,7 +93,7 @@ fn get_root() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt);
+    let ms = MerkleStore::from(&mt);
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
     let pmt = PartialMerkleTree::with_paths([(3, path33.value, path33.path)]).unwrap();
@@ -109,7 +109,7 @@ fn add_and_get_paths() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt);
+    let ms = MerkleStore::from(&mt);
 
     let expected_path33 = ms.get_path(expected_root, NODE33).unwrap();
     let expected_path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -133,7 +133,7 @@ fn get_node() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt);
+    let ms = MerkleStore::from(&mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -150,7 +150,7 @@ fn update_leaf() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let root = mt.root();
 
-    let mut ms = MerkleStore::from(mt);
+    let mut ms = MerkleStore::from(&mt);
     let path33 = ms.get_path(root, NODE33).unwrap();
 
     let mut pmt = PartialMerkleTree::with_paths([(3, path33.value, path33.path)]).unwrap();
@@ -186,7 +186,7 @@ fn get_paths() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt.clone());
+    let ms = MerkleStore::from(&mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -233,7 +233,7 @@ fn leaves() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt.clone());
+    let ms = MerkleStore::from(&mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -299,7 +299,7 @@ fn test_inner_node_iterator() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt.clone());
+    let ms = MerkleStore::from(&mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -366,7 +366,7 @@ fn serialization() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt);
+    let ms = MerkleStore::from(&mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
     let path22 = ms.get_path(expected_root, NODE22).unwrap();
@@ -418,7 +418,7 @@ fn err_get_node() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt);
+    let ms = MerkleStore::from(&mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -436,7 +436,7 @@ fn err_get_path() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt);
+    let ms = MerkleStore::from(&mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 
@@ -453,7 +453,7 @@ fn err_update_leaf() {
     let mt = MerkleTree::new(VALUES8).unwrap();
     let expected_root = mt.root();
 
-    let ms = MerkleStore::from(mt);
+    let ms = MerkleStore::from(&mt);
 
     let path33 = ms.get_path(expected_root, NODE33).unwrap();
 

--- a/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
+++ b/miden-crypto/src/merkle/smt/full/concurrent/tests.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::{
     EMPTY_WORD, ONE, ZERO,
-    merkle::{LeafIndex, MerkleError, smt::Felt},
+    merkle::{InnerNodeIterable, LeafIndex, MerkleError, smt::Felt},
 };
 
 fn smtleaf_to_subtree_leaf(leaf: &SmtLeaf) -> SubtreeLeaf {

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -4,6 +4,7 @@ use super::{
     EMPTY_WORD, EmptySubtreeRoots, Felt, InnerNode, InnerNodeInfo, InnerNodes, LeafIndex,
     MerkleError, MerklePath, MutationSet, NodeIndex, Rpo256, SparseMerkleTree, Word,
 };
+use crate::merkle::InnerNodeIterable;
 
 mod error;
 pub use error::{SmtLeafError, SmtProofError};
@@ -233,15 +234,6 @@ impl Smt {
     /// Returns an iterator over the key-value pairs of this [Smt] in arbitrary order.
     pub fn entries(&self) -> impl Iterator<Item = &(Word, Word)> {
         self.leaves().flat_map(|(_, leaf)| leaf.entries())
-    }
-
-    /// Returns an iterator over the inner nodes of this [Smt].
-    pub fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
-        self.inner_nodes.values().map(|e| InnerNodeInfo {
-            value: e.hash(),
-            left: e.left,
-            right: e.right,
-        })
     }
 
     // STATE MUTATORS
@@ -474,6 +466,20 @@ impl SparseMerkleTree<SMT_DEPTH> for Smt {
 impl Default for Smt {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ITERATORS
+// ================================================================================================
+
+impl InnerNodeIterable for Smt {
+    /// Returns an iterator over the inner nodes of this [Smt].
+    fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
+        self.inner_nodes.values().map(|e| InnerNodeInfo {
+            value: e.hash(),
+            left: e.left,
+            right: e.right,
+        })
     }
 }
 

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -473,7 +473,7 @@ impl Default for Smt {
 // ================================================================================================
 
 impl InnerNodeIterable for Smt {
-    /// Returns an iterator over the inner nodes of this [Smt].
+    /// Returns an iterator over the inner nodes of this [`Smt`].
     fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
         self.inner_nodes.values().map(|e| InnerNodeInfo {
             value: e.hash(),

--- a/miden-crypto/src/merkle/smt/partial.rs
+++ b/miden-crypto/src/merkle/smt/partial.rs
@@ -4,7 +4,8 @@ use super::{LeafIndex, SMT_DEPTH};
 use crate::{
     EMPTY_WORD, Word,
     merkle::{
-        InnerNode, InnerNodeInfo, MerkleError, MerklePath, NodeIndex, Smt, SmtLeaf, SmtProof,
+        InnerNode, InnerNodeInfo, InnerNodeIterable, MerkleError, MerklePath, NodeIndex, Smt,
+        SmtLeaf, SmtProof,
         smt::{InnerNodes, Leaves, SparseMerkleTree},
     },
 };
@@ -229,11 +230,6 @@ impl PartialSmt {
         self.0.leaves.contains_key(&Smt::key_to_leaf_index(key).value())
     }
 
-    /// Returns an iterator over the inner nodes of the [`PartialSmt`].
-    pub fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
-        self.0.inner_nodes()
-    }
-
     /// Returns an iterator over the tracked, non-empty leaves of the [`PartialSmt`] in arbitrary
     /// order.
     pub fn leaves(&self) -> impl Iterator<Item = (LeafIndex<SMT_DEPTH>, &SmtLeaf)> {
@@ -337,6 +333,16 @@ impl Deserializable for PartialSmt {
 
         let smt = Smt::from_raw_parts(nodes, leaves, root);
         Ok(PartialSmt(smt))
+    }
+}
+
+// ITERATORS
+// ================================================================================================
+
+impl InnerNodeIterable for PartialSmt {
+    /// Returns an iterator over the inner nodes of the [`PartialSmt`].
+    fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
+        self.0.inner_nodes()
     }
 }
 

--- a/miden-crypto/src/merkle/smt/simple/mod.rs
+++ b/miden-crypto/src/merkle/smt/simple/mod.rs
@@ -420,7 +420,7 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
 // ================================================================================================
 
 impl<const DEPTH: u8> InnerNodeIterable for SimpleSmt<DEPTH> {
-    /// Returns an iterator over the inner nodes of this [SimpleSmt].
+    /// Returns an iterator over the inner nodes of this [`SimpleSmt`].
     fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
         self.inner_nodes.values().map(|e| InnerNodeInfo {
             value: e.hash(),

--- a/miden-crypto/src/merkle/smt/simple/mod.rs
+++ b/miden-crypto/src/merkle/smt/simple/mod.rs
@@ -5,7 +5,7 @@ use super::{
     LeafIndex, MerkleError, MerklePath, MutationSet, NodeIndex, SMT_MAX_DEPTH, SMT_MIN_DEPTH,
     SparseMerkleTree, Word,
 };
-use crate::merkle::{SparseMerklePath, SparseValuePath};
+use crate::merkle::{InnerNodeIterable, SparseMerklePath, SparseValuePath};
 
 #[cfg(test)]
 mod tests;
@@ -193,15 +193,6 @@ impl<const DEPTH: u8> SimpleSmt<DEPTH> {
     /// Returns an iterator over the leaves of this [SimpleSmt].
     pub fn leaves(&self) -> impl Iterator<Item = (u64, &Word)> {
         self.leaves.iter().map(|(i, w)| (*i, w))
-    }
-
-    /// Returns an iterator over the inner nodes of this [SimpleSmt].
-    pub fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
-        self.inner_nodes.values().map(|e| InnerNodeInfo {
-            value: e.hash(),
-            left: e.left,
-            right: e.right,
-        })
     }
 
     // STATE MUTATORS
@@ -422,5 +413,19 @@ impl<const DEPTH: u8> SparseMerkleTree<DEPTH> for SimpleSmt<DEPTH> {
 
     fn path_and_leaf_to_opening(path: MerklePath, leaf: Word) -> ValuePath {
         (path, leaf).into()
+    }
+}
+
+// ITERATORS
+// ================================================================================================
+
+impl<const DEPTH: u8> InnerNodeIterable for SimpleSmt<DEPTH> {
+    /// Returns an iterator over the inner nodes of this [SimpleSmt].
+    fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
+        self.inner_nodes.values().map(|e| InnerNodeInfo {
+            value: e.hash(),
+            left: e.left,
+            right: e.right,
+        })
     }
 }

--- a/miden-crypto/src/merkle/smt/simple/tests.rs
+++ b/miden-crypto/src/merkle/smt/simple/tests.rs
@@ -10,8 +10,8 @@ use crate::{
     EMPTY_WORD,
     hash::rpo::Rpo256,
     merkle::{
-        EmptySubtreeRoots, InnerNodeInfo, LeafIndex, MerklePath, MerkleTree, int_to_leaf,
-        int_to_node, smt::SparseMerkleTree,
+        EmptySubtreeRoots, InnerNodeInfo, InnerNodeIterable, LeafIndex, MerklePath, MerkleTree,
+        int_to_leaf, int_to_node, smt::SparseMerkleTree,
     },
 };
 

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -60,8 +60,8 @@ pub struct StoreNode {
 /// let tree2 = MerkleTree::new(vec![A, B, C, D, E, F, G, H1]).unwrap();
 ///
 /// // populates the store with two merkle trees, common nodes are shared
-/// store.extend(tree1.inner_nodes());
-/// store.extend(tree2.inner_nodes());
+/// store.extend(tree1);
+/// store.extend(tree2);
 ///
 /// // every leaf except the last are the same
 /// for i in 0..7 {
@@ -477,9 +477,9 @@ impl MerkleStore {
 // CONVERSIONS
 // ================================================================================================
 
-impl From<&MerkleTree> for MerkleStore {
-    fn from(value: &MerkleTree) -> Self {
-        let nodes = combine_nodes_with_empty_hashes(value.inner_nodes()).collect();
+impl From<MerkleTree> for MerkleStore {
+    fn from(value: MerkleTree) -> Self {
+        let nodes = combine_nodes_with_empty_hashes(value).collect();
         Self { nodes }
     }
 }

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -2,8 +2,8 @@ use alloc::vec::Vec;
 use core::borrow::Borrow;
 
 use super::{
-    EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, MerkleTree, NodeIndex,
-    PartialMerkleTree, RootPath, Rpo256, SimpleSmt, Smt, ValuePath, Word, mmr::Mmr,
+    EmptySubtreeRoots, InnerNodeInfo, InnerNodeIterable, MerkleError, MerklePath, MerkleTree,
+    NodeIndex, PartialMerkleTree, RootPath, Rpo256, SimpleSmt, Smt, ValuePath, Word, mmr::Mmr,
 };
 use crate::{
     Map,
@@ -328,13 +328,6 @@ impl MerkleStore {
         store
     }
 
-    /// Iterator over the inner nodes of the [MerkleStore].
-    pub fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> + '_ {
-        self.nodes
-            .iter()
-            .map(|(r, n)| InnerNodeInfo { value: *r, left: n.left, right: n.right })
-    }
-
     /// Iterator over the non-empty leaves of the Merkle tree associated with the specified `root`
     /// and `max_depth`.
     pub fn non_empty_leaves(
@@ -534,6 +527,15 @@ impl Extend<InnerNodeInfo> for MerkleStore {
             iter.into_iter()
                 .map(|info| (info.value, StoreNode { left: info.left, right: info.right })),
         );
+    }
+}
+
+impl InnerNodeIterable for MerkleStore {
+    /// Iterator over the inner nodes of the [MerkleStore].
+    fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
+        self.nodes
+            .iter()
+            .map(|(r, n)| InnerNodeInfo { value: *r, left: n.left, right: n.right })
     }
 }
 

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -60,8 +60,8 @@ pub struct StoreNode {
 /// let tree2 = MerkleTree::new(vec![A, B, C, D, E, F, G, H1]).unwrap();
 ///
 /// // populates the store with two merkle trees, common nodes are shared
-/// store.extend(tree1);
-/// store.extend(tree2);
+/// store.extend(tree1.inner_nodes());
+/// store.extend(tree2.inner_nodes());
 ///
 /// // every leaf except the last are the same
 /// for i in 0..7 {
@@ -477,9 +477,9 @@ impl MerkleStore {
 // CONVERSIONS
 // ================================================================================================
 
-impl From<MerkleTree> for MerkleStore {
-    fn from(value: MerkleTree) -> Self {
-        let nodes = combine_nodes_with_empty_hashes(value).collect();
+impl From<&MerkleTree> for MerkleStore {
+    fn from(value: &MerkleTree) -> Self {
+        let nodes = combine_nodes_with_empty_hashes(value.inner_nodes()).collect();
         Self { nodes }
     }
 }

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -531,7 +531,7 @@ impl Extend<InnerNodeInfo> for MerkleStore {
 }
 
 impl InnerNodeIterable for MerkleStore {
-    /// Iterator over the inner nodes of the [MerkleStore].
+    /// Iterator over the inner nodes of the [`MerkleStore`].
     fn inner_nodes(&self) -> impl Iterator<Item = InnerNodeInfo> {
         self.nodes
             .iter()

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -33,7 +33,7 @@ pub struct StoreNode {
 ///
 /// ```rust
 /// # use miden_crypto::{ZERO, Felt, Word};
-/// # use miden_crypto::merkle::{NodeIndex, MerkleStore, MerkleTree};
+/// # use miden_crypto::merkle::{InnerNodeIterable, NodeIndex, MerkleStore, MerkleTree};
 /// # use miden_crypto::hash::rpo::Rpo256;
 /// # const fn int_to_node(value: u64) -> Word {
 /// #     Word::new([Felt::new(value), ZERO, ZERO, ZERO])

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -101,11 +101,16 @@ impl MerkleStore {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Creates an empty `MerkleStore` instance.
+    /// Creates an empty [`MerkleStore`] instance.
     pub fn new() -> MerkleStore {
         // pre-populate the store with the empty hashes
         let nodes = empty_hashes().collect();
         MerkleStore { nodes }
+    }
+
+    /// Creates a [`MerkleStore`] instance from a list of inner nodes.
+    pub fn from_inner_nodes(inner_nodes_iterable: impl IntoIterator<Item = InnerNodeInfo>) -> Self {
+        inner_nodes_iterable.into_iter().collect()
     }
 
     // PUBLIC ACCESSORS

--- a/miden-crypto/src/merkle/store/tests.rs
+++ b/miden-crypto/src/merkle/store/tests.rs
@@ -39,7 +39,7 @@ const VALUES8: [Word; 8] = [
 #[test]
 fn test_root_not_in_store() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let store = MerkleStore::from(mtree.clone());
+    let store = MerkleStore::from(&mtree);
     assert_matches!(
         store.get_node(VALUES4[0], NodeIndex::make(mtree.depth(), 0)),
         Err(MerkleError::RootNotInStore(root)) if root == VALUES4[0],
@@ -57,7 +57,7 @@ fn test_root_not_in_store() -> Result<(), MerkleError> {
 #[test]
 fn test_merkle_tree() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let store = MerkleStore::from(mtree.clone());
+    let store = MerkleStore::from(&mtree);
 
     // STORE LEAVES ARE CORRECT -------------------------------------------------------------------
     // checks the leaves in the store corresponds to the expected values
@@ -204,7 +204,7 @@ fn test_leaf_paths_for_empty_trees() -> Result<(), MerkleError> {
 #[test]
 fn test_get_invalid_node() {
     let mtree = MerkleTree::new(VALUES4).expect("creating a merkle tree must work");
-    let store = MerkleStore::from(mtree.clone());
+    let store = MerkleStore::from(&mtree);
     let _ = store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 3));
 }
 
@@ -491,7 +491,7 @@ fn wont_open_to_different_depth_root() {
     // attempt to fetch a node on the maximum depth, and it should fail because the root shouldn't
     // exist for the set.
     let mtree = MerkleTree::new(vec![a, b]).unwrap();
-    let store = MerkleStore::from(mtree);
+    let store = MerkleStore::from(&mtree);
     let index = NodeIndex::root();
     let err = store.get_node(root, index).err().unwrap();
     assert_matches!(err, MerkleError::RootNotInStore(err_root) if err_root == root);
@@ -519,7 +519,7 @@ fn store_path_opens_from_leaf() {
     let root = Rpo256::merge(&[m, n]);
 
     let mtree = MerkleTree::new(vec![a, b, c, d, e, f, g, h]).unwrap();
-    let store = MerkleStore::from(mtree);
+    let store = MerkleStore::from(&mtree);
     let path = store.get_path(root, NodeIndex::make(3, 1)).unwrap().path;
 
     let expected = MerklePath::new([a, j, n].to_vec());
@@ -529,7 +529,7 @@ fn store_path_opens_from_leaf() {
 #[test]
 fn test_set_node() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let mut store = MerkleStore::from(mtree.clone());
+    let mut store = MerkleStore::from(&mtree);
     let value = int_to_node(42);
     let index = NodeIndex::make(mtree.depth(), 0);
     let new_root = store.set_node(mtree.root(), index, value)?.root;
@@ -541,7 +541,7 @@ fn test_set_node() -> Result<(), MerkleError> {
 #[test]
 fn test_constructors() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let store = MerkleStore::from(mtree.clone());
+    let store = MerkleStore::from(&mtree);
 
     let depth = mtree.depth();
     let leaves = 2u64.pow(depth.into());
@@ -813,7 +813,7 @@ fn mstore_subset() {
     let mtree = MerkleTree::new(VALUES8).unwrap();
     let mut store = MerkleStore::default();
     let empty_store_num_nodes = store.nodes.len();
-    store.extend(mtree);
+    store.extend(mtree.inner_nodes());
 
     // build 3 subtrees contained within the above Merkle tree; note that subtree2 is a subset
     // of subtree1
@@ -865,7 +865,7 @@ fn check_mstore_subtree(store: &MerkleStore, subtree: &MerkleTree) {
 #[test]
 fn test_serialization() -> Result<(), Box<dyn Error>> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let store = MerkleStore::from(mtree);
+    let store = MerkleStore::from(&mtree);
     let decoded = MerkleStore::read_from_bytes(&store.to_bytes()).expect("deserialization failed");
     assert_eq!(store, decoded);
     Ok(())

--- a/miden-crypto/src/merkle/store/tests.rs
+++ b/miden-crypto/src/merkle/store/tests.rs
@@ -13,7 +13,10 @@ use super::{
 };
 use crate::{
     Felt, ONE, WORD_SIZE, ZERO,
-    merkle::{LeafIndex, MerkleTree, SMT_MAX_DEPTH, SimpleSmt, int_to_leaf, int_to_node},
+    merkle::{
+        InnerNodeIterable, LeafIndex, MerkleTree, SMT_MAX_DEPTH, SimpleSmt, int_to_leaf,
+        int_to_node,
+    },
 };
 
 // TEST DATA

--- a/miden-crypto/src/merkle/store/tests.rs
+++ b/miden-crypto/src/merkle/store/tests.rs
@@ -39,7 +39,7 @@ const VALUES8: [Word; 8] = [
 #[test]
 fn test_root_not_in_store() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let store = MerkleStore::from(&mtree);
+    let store = MerkleStore::from(mtree.clone());
     assert_matches!(
         store.get_node(VALUES4[0], NodeIndex::make(mtree.depth(), 0)),
         Err(MerkleError::RootNotInStore(root)) if root == VALUES4[0],
@@ -57,7 +57,7 @@ fn test_root_not_in_store() -> Result<(), MerkleError> {
 #[test]
 fn test_merkle_tree() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let store = MerkleStore::from(&mtree);
+    let store = MerkleStore::from(mtree.clone());
 
     // STORE LEAVES ARE CORRECT -------------------------------------------------------------------
     // checks the leaves in the store corresponds to the expected values
@@ -204,7 +204,7 @@ fn test_leaf_paths_for_empty_trees() -> Result<(), MerkleError> {
 #[test]
 fn test_get_invalid_node() {
     let mtree = MerkleTree::new(VALUES4).expect("creating a merkle tree must work");
-    let store = MerkleStore::from(&mtree);
+    let store = MerkleStore::from(mtree.clone());
     let _ = store.get_node(mtree.root(), NodeIndex::make(mtree.depth(), 3));
 }
 
@@ -491,7 +491,7 @@ fn wont_open_to_different_depth_root() {
     // attempt to fetch a node on the maximum depth, and it should fail because the root shouldn't
     // exist for the set.
     let mtree = MerkleTree::new(vec![a, b]).unwrap();
-    let store = MerkleStore::from(&mtree);
+    let store = MerkleStore::from(mtree);
     let index = NodeIndex::root();
     let err = store.get_node(root, index).err().unwrap();
     assert_matches!(err, MerkleError::RootNotInStore(err_root) if err_root == root);
@@ -519,7 +519,7 @@ fn store_path_opens_from_leaf() {
     let root = Rpo256::merge(&[m, n]);
 
     let mtree = MerkleTree::new(vec![a, b, c, d, e, f, g, h]).unwrap();
-    let store = MerkleStore::from(&mtree);
+    let store = MerkleStore::from(mtree);
     let path = store.get_path(root, NodeIndex::make(3, 1)).unwrap().path;
 
     let expected = MerklePath::new([a, j, n].to_vec());
@@ -529,7 +529,7 @@ fn store_path_opens_from_leaf() {
 #[test]
 fn test_set_node() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let mut store = MerkleStore::from(&mtree);
+    let mut store = MerkleStore::from(mtree.clone());
     let value = int_to_node(42);
     let index = NodeIndex::make(mtree.depth(), 0);
     let new_root = store.set_node(mtree.root(), index, value)?.root;
@@ -541,7 +541,7 @@ fn test_set_node() -> Result<(), MerkleError> {
 #[test]
 fn test_constructors() -> Result<(), MerkleError> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let store = MerkleStore::from(&mtree);
+    let store = MerkleStore::from(mtree.clone());
 
     let depth = mtree.depth();
     let leaves = 2u64.pow(depth.into());
@@ -813,7 +813,7 @@ fn mstore_subset() {
     let mtree = MerkleTree::new(VALUES8).unwrap();
     let mut store = MerkleStore::default();
     let empty_store_num_nodes = store.nodes.len();
-    store.extend(mtree.inner_nodes());
+    store.extend(mtree);
 
     // build 3 subtrees contained within the above Merkle tree; note that subtree2 is a subset
     // of subtree1
@@ -865,7 +865,7 @@ fn check_mstore_subtree(store: &MerkleStore, subtree: &MerkleTree) {
 #[test]
 fn test_serialization() -> Result<(), Box<dyn Error>> {
     let mtree = MerkleTree::new(VALUES4)?;
-    let store = MerkleStore::from(&mtree);
+    let store = MerkleStore::from(mtree);
     let decoded = MerkleStore::read_from_bytes(&store.to_bytes()).expect("deserialization failed");
     assert_eq!(store, decoded);
     Ok(())


### PR DESCRIPTION
## Context

Closes #444.

There is a concern that we use `From<&T>` involving unnecessary allocations in situations where moves are applicable instead.

## Changes
- Add `impl IntoIterator for MerkleStore` and replace `fn into_iter`.
- Replace `impl From<&MerkleTree> for MerkleStore` with `impl From<MerkleTree> for MerkleStore`.
    - Clone calls added where required.