### PR TITLE
Fix Polynomial Coefficient Boundaries and Typo in MMR Test

### DIFF
--- a/miden-crypto/src/dsa/rpo_falcon512/math/mod.rs
+++ b/miden-crypto/src/dsa/rpo_falcon512/math/mod.rs
@@ -34,8 +34,8 @@ use self::samplerz::sampler_z;
 mod polynomial;
 pub use polynomial::Polynomial;
 
-const MAX_SMALL_POLY_COEFFICENT_SIZE: i16 = (1 << (WIDTH_SMALL_POLY_COEFFICIENT - 1)) - 1;
-const MAX_BIG_POLY_COEFFICENT_SIZE: i16 = (1 << (WIDTH_BIG_POLY_COEFFICIENT - 1)) - 1;
+const MAX_SMALL_POLY_COEFFICIENT_SIZE: i16 = (1 << (WIDTH_SMALL_POLY_COEFFICIENT - 1)) - 1;
+const MAX_BIG_POLY_COEFFICIENT_SIZE: i16 = (1 << (WIDTH_BIG_POLY_COEFFICIENT - 1)) - 1;
 
 pub trait Inverse: Copy + Zero + MulAssign + One {
     /// Gets the inverse of a, or zero if it is zero.
@@ -94,8 +94,8 @@ pub(crate) fn ntru_gen<R: Rng>(n: usize, rng: &mut R) -> [Polynomial<i16>; 4] {
 
         // we do bound checks on the coefficients of the sampled polynomials in order to make sure
         // that they will be encodable/decodable
-        if !(check_coefficients_bound(&f, MAX_SMALL_POLY_COEFFICENT_SIZE)
-            && check_coefficients_bound(&g, MAX_SMALL_POLY_COEFFICENT_SIZE))
+        if !(check_coefficients_bound(&f, MAX_SMALL_POLY_COEFFICIENT_SIZE)
+            && check_coefficients_bound(&g, MAX_SMALL_POLY_COEFFICIENT_SIZE))
         {
             continue;
         }
@@ -116,8 +116,8 @@ pub(crate) fn ntru_gen<R: Rng>(n: usize, rng: &mut R) -> [Polynomial<i16>; 4] {
             // sure that they will be encodable/decodable
             let capital_f = capital_f.map(|i| i.try_into().unwrap());
             let capital_g = capital_g.map(|i| i.try_into().unwrap());
-            if !(check_coefficients_bound(&capital_f, MAX_BIG_POLY_COEFFICENT_SIZE)
-                && check_coefficients_bound(&capital_g, MAX_BIG_POLY_COEFFICENT_SIZE))
+            if !(check_coefficients_bound(&capital_f, MAX_BIG_POLY_COEFFICIENT_SIZE)
+                && check_coefficients_bound(&capital_g, MAX_BIG_POLY_COEFFICIENT_SIZE))
             {
                 continue;
             }

--- a/miden-crypto/src/merkle/mmr/tests.rs
+++ b/miden-crypto/src/merkle/mmr/tests.rs
@@ -1027,7 +1027,7 @@ mod property_tests {
 
     proptest! {
         #[test]
-        fn test_last_position_is_always_contained_in_the_last_tree(leaves in any::<usize>().prop_filter("cant have an empty tree", |v| *v != 0)) {
+        fn test_last_position_is_always_contained_in_the_last_tree(leaves in any::<usize>().prop_filter("can't have an empty tree", |v| *v != 0)) {
             let last_pos = leaves - 1;
             let lowest_bit = leaves.trailing_zeros();
 


### PR DESCRIPTION


**Description:**  
- Updated constant names for polynomial coefficient size checks in Falcon512 math module for clarity and consistency.
- Fixed a typo in the MMR property test error message ("cant" → "can't").
- Minor code cleanups to improve readability and maintainability.