### PR TITLE
feat: Conversions, serde for PartialSmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.5 (2025-07-10)
+## 0.15.6 (2025-07-15)
 
 - Added conversions and seralization for `PartialSmt` ([#451](https://github.com/0xMiden/crypto/pull/451/)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.15.5 (2025-07-10)
 
+- Added conversions and seralization for `PartialSmt` ([#451](https://github.com/0xMiden/crypto/pull/451/)).
+
+## 0.15.5 (2025-07-10)
+
 - Added `empty()` and `is_empty()` methods to `Word`.
 
 ## 0.15.4 (2025-07-07)


### PR DESCRIPTION
## Changes

Adds conversion from `Smt` for `PartialSmt` and serialization implementations, for completion and for https://github.com/0xMiden/miden-base/issues/1457. 
