### PR TITLE
fix: Complete partial SMT (de)serialization

### DIFF
--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -52,7 +52,7 @@ pub struct Smt {
     root: Word,
     // pub(super) for use in PartialSmt.
     pub(super) leaves: Leaves,
-    inner_nodes: InnerNodes,
+    pub(super) inner_nodes: InnerNodes,
 }
 
 impl Smt {


### PR DESCRIPTION
## Changes

Fixes serialization and deserialization code for `PartialSmt` (see https://github.com/0xMiden/crypto/pull/451#discussion_r2208732315 for reference).
