### PR TITLE
Remove partial_smt_serialization_rounfdtrip test with a typo

### DIFF
--- a/miden-crypto/src/merkle/smt/partial.rs
+++ b/miden-crypto/src/merkle/smt/partial.rs
@@ -672,13 +672,4 @@ mod tests {
 
         assert_eq!(partial_smt, decoded);
     }
-
-    #[test]
-    fn partial_smt_serialization_rounfdtrip() {
-        let partial_smt = PartialSmt::new();
-        let bytes = partial_smt.to_bytes();
-        let decoded = PartialSmt::read_from_bytes(&bytes).unwrap();
-
-        assert_eq!(partial_smt, decoded);
-    }
 }


### PR DESCRIPTION
## Describe your changes
I believe this test shouldn't exist. It's a subset of the test above and contains a typo in its name.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
