### PR TITLE
Add ECDSA over secp256k1 curve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,8 +490,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -692,7 +694,7 @@ dependencies = [
  "cc",
  "clap",
  "criterion",
- "getrandom 0.3.3",
+ "getrandom 0.2.16",
  "glob",
  "hashbrown",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +325,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,13 +347,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -333,10 +389,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "foldhash"
@@ -395,6 +480,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -406,7 +503,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -414,6 +511,17 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "half"
@@ -449,6 +557,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "indexmap"
@@ -505,7 +622,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -517,6 +634,20 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -561,17 +692,18 @@ dependencies = [
  "cc",
  "clap",
  "criterion",
- "getrandom",
+ "getrandom 0.3.3",
  "glob",
  "hashbrown",
  "hex",
  "itertools 0.14.0",
+ "k256",
  "num",
  "num-complex",
  "proptest",
  "rand",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
  "rayon",
  "rstest",
  "seq-macro",
@@ -689,6 +821,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -789,7 +931,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -798,7 +949,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -807,7 +958,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -864,6 +1015,16 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
 
 [[package]]
 name = "rstest"
@@ -926,6 +1087,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1145,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,16 +1172,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1094,6 +1306,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1329,3 +1547,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -64,6 +64,7 @@ std = [
 [dependencies]
 blake3 = { version = "1.8", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
+getrandom = { version = "0.2", features = ["js"] }
 hashbrown = { version = "0.15", optional = true, features = ["serde"] }
 k256 = { version = "0.13", features = ["ecdsa"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
@@ -83,7 +84,6 @@ winter-utils = { version = "0.13", default-features = false }
 [dev-dependencies]
 assert_matches = { version = "1.5", default-features = false }
 criterion = { version = "0.6", features = ["html_reports"] }
-getrandom = { version = "0.2", features = ["js"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 itertools = { version = "0.14" }
 proptest = { version = "1.7", default-features = false, features = ["alloc"] }

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -83,7 +83,7 @@ winter-utils = { version = "0.13", default-features = false }
 [dev-dependencies]
 assert_matches = { version = "1.5", default-features = false }
 criterion = { version = "0.6", features = ["html_reports"] }
-getrandom = { version = "0.3", default-features = false }
+getrandom = { version = "0.2", features = ["js"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 itertools = { version = "0.14" }
 proptest = { version = "1.7", default-features = false, features = ["alloc"] }

--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -65,6 +65,7 @@ std = [
 blake3 = { version = "1.8", default-features = false }
 clap = { version = "4.5", optional = true, features = ["derive"] }
 hashbrown = { version = "0.15", optional = true, features = ["serde"] }
+k256 = { version = "0.13", features = ["ecdsa"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
 num-complex = { version = "0.4", default-features = false }
 rand = { version = "0.9", default-features = false }

--- a/miden-crypto/src/dsa/ecdsa_secp256k1/mod.rs
+++ b/miden-crypto/src/dsa/ecdsa_secp256k1/mod.rs
@@ -1,0 +1,229 @@
+//! ECDSA (Elliptic Curve Digital Signature Algorithm) signature implementation over secp256k1
+//! curve.
+
+use alloc::{string::ToString, vec::Vec};
+
+use k256::{
+    ecdsa::{
+        SigningKey, VerifyingKey,
+        signature::{Signer, Verifier},
+    },
+    elliptic_curve::rand_core::{CryptoRng, RngCore},
+};
+
+use crate::{
+    Felt, SequentialCommit, StarkField, Word,
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
+
+// CONSTANTS
+// ================================================================================================
+
+const SECRET_KEY_BYTES: usize = 32;
+const PUBLIC_KEY_BYTES: usize = 33; // we use the compressed format
+const SIGNATURE_BYTES: usize = 64;
+
+// SECRET KEY
+// ================================================================================================
+
+/// Secret key for ECDSA signature verification over secp256k1 curve.
+#[derive(Clone)]
+pub struct SecretKey {
+    inner: SigningKey,
+}
+
+impl SecretKey {
+    /// Generate a new random secret key using the OS random number generator.
+    #[cfg(feature = "std")]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let mut rng = k256::elliptic_curve::rand_core::OsRng;
+
+        Self::with_rng(&mut rng)
+    }
+
+    /// Generate a new secret key using the provided random number generator.
+    pub fn with_rng<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+        let signing_key = SigningKey::random(rng);
+        Self { inner: signing_key }
+    }
+
+    /// Get the corresponding public key for this secret key.
+    pub fn public_key(&self) -> PublicKey {
+        let verifying_key = self.inner.verifying_key();
+        PublicKey { inner: *verifying_key }
+    }
+
+    /// Sign a message (represented as a Word) with this secret key.
+    pub fn sign(&mut self, message: Word) -> Signature {
+        // Convert Word to bytes for signing
+        let message_bytes: [u8; 32] = message.into();
+
+        // Sign the message
+        let signature: k256::ecdsa::Signature = self.inner.sign(&message_bytes);
+
+        Signature { inner: signature }
+    }
+}
+
+// PUBLIC KEY
+// ================================================================================================
+
+/// Public key for ECDSA signature verification over secp256k1 curve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicKey {
+    inner: VerifyingKey,
+}
+
+impl PublicKey {
+    /// Convert public key to a Word representation for use in Miden.
+    pub fn to_word(&self) -> Word {
+        self.to_commitment()
+    }
+
+    /// Verify a signature against this public key and message.
+    pub fn verify(&self, message: Word, signature: &Signature) -> bool {
+        let message_bytes: [u8; 32] = message.into();
+        self.inner.verify(&message_bytes, &signature.inner).is_ok()
+    }
+}
+
+impl SequentialCommit for PublicKey {
+    type Commitment = Word;
+
+    fn to_elements(&self) -> Vec<Felt> {
+        self.to_bytes().chunks(5).map(Felt::from_bytes_with_padding).collect()
+    }
+}
+
+// SIGNATURE
+// ================================================================================================
+
+/// ECDSA signature over secp256k1 curve
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Signature {
+    inner: k256::ecdsa::Signature,
+}
+
+impl Signature {
+    /// Verify this signature against a message and public key..
+    pub fn verify(&self, message: Word, pub_key: &PublicKey) -> bool {
+        pub_key.verify(message, self)
+    }
+}
+
+// SERIALIZATION / DESERIALIZATION
+// ================================================================================================
+
+impl Serializable for SecretKey {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        let mut buffer = Vec::with_capacity(SECRET_KEY_BYTES);
+        let sk_bytes: [u8; SECRET_KEY_BYTES] = self.inner.to_bytes().into();
+        buffer.extend_from_slice(&sk_bytes);
+
+        target.write_bytes(&buffer);
+    }
+}
+
+impl Deserializable for SecretKey {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let bytes: [u8; SECRET_KEY_BYTES] = source.read_array()?;
+
+        let signing_key = SigningKey::from_slice(&bytes)
+            .map_err(|_| DeserializationError::InvalidValue("Invalid secret key".to_string()))?;
+
+        Ok(Self { inner: signing_key })
+    }
+}
+
+impl Serializable for PublicKey {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        // Compressed format
+        let encoded = self.inner.to_encoded_point(true);
+
+        target.write_bytes(encoded.as_bytes());
+    }
+}
+
+impl Deserializable for PublicKey {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let bytes: [u8; PUBLIC_KEY_BYTES] = source.read_array()?;
+
+        let verifying_key = VerifyingKey::from_sec1_bytes(&bytes)
+            .map_err(|_| DeserializationError::InvalidValue("Invalid public key".to_string()))?;
+
+        Ok(Self { inner: verifying_key })
+    }
+}
+
+impl Serializable for Signature {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        let bytes: [u8; SIGNATURE_BYTES] = self.inner.to_bytes().into();
+        target.write_bytes(&bytes);
+    }
+}
+
+impl Deserializable for Signature {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let bytes: [u8; SIGNATURE_BYTES] = source.read_array()?;
+
+        let signature = k256::ecdsa::Signature::from_slice(&bytes)
+            .map_err(|_| DeserializationError::InvalidValue("Invalid public key".to_string()))?;
+
+        Ok(Self { inner: signature })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use k256::elliptic_curve::rand_core::OsRng;
+
+    use super::*;
+    use crate::Felt;
+
+    #[test]
+    fn test_key_generation() {
+        let secret_key = SecretKey::with_rng(&mut OsRng);
+        let public_key = secret_key.public_key();
+
+        // Test that we can convert to/from bytes
+        let sk_bytes = secret_key.to_bytes();
+        let recovered_sk = SecretKey::read_from_bytes(&sk_bytes).unwrap();
+        assert_eq!(secret_key.to_bytes(), recovered_sk.to_bytes());
+
+        let pk_bytes = public_key.to_bytes();
+        let recovered_pk = PublicKey::read_from_bytes(&pk_bytes).unwrap();
+        assert_eq!(public_key, recovered_pk);
+    }
+
+    #[test]
+    fn test_sign_and_verify() {
+        let mut secret_key = SecretKey::with_rng(&mut OsRng);
+        let public_key = secret_key.public_key();
+
+        let message = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)].into();
+        let signature = secret_key.sign(message);
+
+        // Verify using public key method
+        assert!(public_key.verify(message, &signature));
+
+        // Verify using signature method
+        assert!(signature.verify(message, &public_key));
+
+        // Test with wrong message
+        let wrong_message = [Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)].into();
+        assert!(!public_key.verify(wrong_message, &signature));
+    }
+
+    #[test]
+    fn test_signature_serialization() {
+        let mut secret_key = SecretKey::with_rng(&mut OsRng);
+        let message = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)].into();
+        let signature = secret_key.sign(message);
+
+        let sig_bytes = signature.to_bytes();
+        let recovered_sig = Signature::read_from_bytes(&sig_bytes).unwrap();
+
+        assert_eq!(signature, recovered_sig);
+    }
+}

--- a/miden-crypto/src/dsa/mod.rs
+++ b/miden-crypto/src/dsa/mod.rs
@@ -1,3 +1,4 @@
 //! Digital signature schemes supported by default in the Miden VM.
 
+pub mod ecdsa_secp256k1;
 pub mod rpo_falcon512;


### PR DESCRIPTION
## Describe your changes
Closes #458 

One question that is still pending is with regards to the need for public key recovery as in Ethereum. Do we need to add this capability?
Or maybe we want to add a specific version that we can call Etheruem ECDSA with that?

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
