### PR TITLE
feat: implement serialization for `Mmr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.15.9 (TBD)
+
+- Added serialization for `Mmr` and `Forest` ([#466](https://github.com/0xMiden/crypto/pull/466)).
+
 # 0.15.8 (2025-07-21)
 
 - Added constructor for `SparseMerklePath` that accepts a bitmask and a vector of nodes ([#457](https://github.com/0xMiden/crypto/pull/457)).

--- a/miden-crypto/src/merkle/mmr/forest.rs
+++ b/miden-crypto/src/merkle/mmr/forest.rs
@@ -3,6 +3,8 @@ use core::{
     ops::{BitAnd, BitOr, BitXor, BitXorAssign},
 };
 
+use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+
 use super::InOrderIndex;
 use crate::Felt;
 
@@ -414,6 +416,22 @@ pub(crate) const fn high_bitmask(bit: u32) -> Forest {
         Forest::empty()
     } else {
         Forest::new(usize::MAX << bit)
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for Forest {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target);
+    }
+}
+
+impl Deserializable for Forest {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let value = source.read_usize()?;
+        Ok(Self::new(value))
     }
 }
 

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -12,6 +12,8 @@
 //! reestablished.
 use alloc::vec::Vec;
 
+use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+
 use super::{
     super::{InnerNodeInfo, MerklePath},
     MmrDelta, MmrError, MmrPeaks, MmrProof,
@@ -339,6 +341,24 @@ where
             mmr.add(v)
         }
         mmr
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for Mmr {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.forest.write_into(target);
+        self.nodes.write_into(target);
+    }
+}
+
+impl Deserializable for Mmr {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let forest = Forest::read_from(source)?;
+        let nodes = source.read_many::<Word>(forest.num_leaves())?;
+        Ok(Self { forest, nodes })
     }
 }
 


### PR DESCRIPTION
This PR implements serialization for the `Mmr` struct, needed to implement serialization for `MockChain` in `miden-base` (implemented in [this PR](https://github.com/0xMiden/miden-base/pull/1642))

The end goal of these changes is to be able to serialize and deserialize the `MockRpcApi` in miden-client (explained in [this issue](https://github.com/0xMiden/miden-client/issues/1064)) 