### PR TITLE
Arithmetization oriented authenticated encryption with associated data (AEAD)

### DIFF
--- a/miden-crypto/Cargo.toml
+++ b/miden-crypto/Cargo.toml
@@ -20,6 +20,10 @@ doctest = false
 required-features = ["executable"]
 
 [[bench]]
+name = "encryption"
+harness = false
+
+[[bench]]
 name = "hash"
 harness = false
 

--- a/miden-crypto/benches/encryption.rs
+++ b/miden-crypto/benches/encryption.rs
@@ -1,0 +1,100 @@
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use miden_crypto::Felt;
+use miden_crypto::encryption::rpo::{Nonce, SecretKey};
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+
+// Test data sizes in bytes
+const DATA_SIZES: &[usize] = &[16, 64, 256, 1024, 4096, 16384, 65536, 262144];
+
+// Field element data sizes
+const FELT_SIZES: &[usize] = &[
+    4,     // 32 bytes equivalent
+    16,    // 128 bytes equivalent
+    64,    // 512 bytes equivalent
+    256,   // 2KB equivalent
+    1024,  // 8KB equivalent
+    4096,  // 32KB equivalent
+    16384, // 128KB equivalent
+];
+
+fn bench_miden_encryption_felts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("miden_encryption_felts");
+
+    let mut rng = ChaCha20Rng::seed_from_u64(42);
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    let associated_data: Vec<Felt> = (0..8).map(|_| Felt::new(rng.next_u64())).collect();
+
+    for &size in FELT_SIZES {
+        // Generate random field elements
+
+        let data: Vec<Felt> = (0..size).map(|_| Felt::new(rng.next_u64())).collect();
+
+        group.throughput(Throughput::Elements(size as u64));
+
+        // Encryption benchmark
+        group.bench_with_input(BenchmarkId::new("encrypt", size), &data, |b, data| {
+            b.iter(|| {
+                black_box(key.encrypt_with_nonce(
+                    black_box(data),
+                    black_box(&associated_data),
+                    black_box(&nonce),
+                ))
+            });
+        });
+
+        // Decryption benchmark
+        let encrypted = key.encrypt_with_nonce(&data, &associated_data, &nonce);
+        group.bench_with_input(BenchmarkId::new("decrypt", size), &encrypted, |b, encrypted| {
+            b.iter(|| black_box(key.decrypt(black_box(encrypted), black_box(&nonce)).unwrap()));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_miden_encryption_bytes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("miden_encryption_bytes");
+
+    let mut rng = ChaCha20Rng::seed_from_u64(42);
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    let mut associated_data = vec![0_u8; 8];
+    rng.fill_bytes(&mut associated_data);
+
+    for &size in DATA_SIZES {
+        let mut data = vec![0u8; size];
+        rng.fill_bytes(&mut data);
+
+        group.throughput(Throughput::Bytes(size as u64));
+
+        // Encryption benchmark
+        group.bench_with_input(BenchmarkId::new("encrypt", size), &data, |b, data| {
+            b.iter(|| {
+                black_box(key.encrypt_bytes_with_nonce(
+                    black_box(data),
+                    black_box(&associated_data),
+                    black_box(&nonce),
+                ))
+            });
+        });
+
+        // Decryption benchmark
+        let encrypted = key.encrypt_bytes_with_nonce(&data, &associated_data, &nonce);
+        group.bench_with_input(BenchmarkId::new("decrypt", size), &encrypted, |b, encrypted| {
+            b.iter(|| {
+                black_box(key.decrypt_bytes(black_box(encrypted), black_box(&nonce)).unwrap())
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(encryption_group, bench_miden_encryption_felts, bench_miden_encryption_bytes,);
+criterion_main!(encryption_group);

--- a/miden-crypto/benches/encryption.rs
+++ b/miden-crypto/benches/encryption.rs
@@ -1,8 +1,10 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use miden_crypto::Felt;
-use miden_crypto::encryption::rpo::{Nonce, SecretKey};
+use miden_crypto::{
+    Felt,
+    encryption::{Nonce, SecretKey},
+};
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 

--- a/miden-crypto/src/encryption/mod.rs
+++ b/miden-crypto/src/encryption/mod.rs
@@ -1,0 +1,342 @@
+use core::fmt;
+use core::ops::Range;
+
+use alloc::vec::Vec;
+
+use num::Integer;
+use rand::Rng;
+use rand::distr::{Distribution, StandardUniform, Uniform};
+use winter_math::StarkField;
+
+use crate::hash::rpo::Rpo256;
+use crate::{Felt, ONE, ZERO};
+
+#[cfg(test)]
+mod test;
+
+// CONSTANTS
+// ================================================================================================
+
+/// Size of a secret key in field elements
+pub const SECRET_KEY_SIZE: usize = 4;
+
+/// Size of a nonce in field elements
+pub const NONCE_SIZE: usize = 4;
+
+/// Size of an authentication tag in field elements
+pub const AUTH_TAG_SIZE: usize = 4;
+
+/// Size of the sponge state field elements
+const STATE_WIDTH: usize = Rpo256::STATE_WIDTH;
+
+/// Rate portion of the sponge state
+const RATE_RANGE: Range<usize> = Rpo256::RATE_RANGE;
+
+/// Size of the rate portion of the sponge state in field elements
+const RATE_WIDTH: usize = RATE_RANGE.end - RATE_RANGE.start;
+
+/// Size of either the 1st or 2nd half of the rate portion of the sponge state in field elements
+const HALF_RATE_WIDTH: usize = (Rpo256::RATE_RANGE.end - Rpo256::RATE_RANGE.start) / 2;
+
+/// First half of the rate portion of the sponge state
+const RATE_RANGE_FIRST_HALF: Range<usize> =
+    Rpo256::RATE_RANGE.start..Rpo256::RATE_RANGE.start + HALF_RATE_WIDTH;
+
+/// Second half of the rate portion of the sponge state
+const RATE_RANGE_SECOND_HALF: Range<usize> =
+    Rpo256::RATE_RANGE.start + HALF_RATE_WIDTH..Rpo256::RATE_RANGE.end;
+
+/// Index of the first element of the rate portion of the sponge state
+const RATE_START: usize = Rpo256::RATE_RANGE.start;
+
+/// Padding block used when the length of the data to encrypt is a multiple of `RATE_WIDTH`
+const PADDING_BLOCK: [Felt; RATE_WIDTH] = [ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO];
+
+// TYPES AND STRUCTURES
+// ================================================================================================
+
+/// A 256-bit secret key represented as 4 field elements
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretKey([Felt; SECRET_KEY_SIZE]);
+
+/// A 256-bit nonce represented as 4 field elements
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Nonce([Felt; NONCE_SIZE]);
+
+/// An authentication tag represented as 4 field elements
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AuthTag([Felt; AUTH_TAG_SIZE]);
+
+/// Encrypted data with its authentication tag
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct EncryptedData {
+    /// The encrypted ciphertext
+    pub ciphertext: Vec<Felt>,
+    /// The authentication tag
+    pub auth_tag: AuthTag,
+}
+
+/// Internal sponge state
+struct SpongeState {
+    state: [Felt; STATE_WIDTH],
+}
+
+impl SpongeState {
+    /// Creates a new sponge state
+    fn new() -> Self {
+        Self { state: [ZERO; STATE_WIDTH] }
+    }
+
+    /// Duplex interface as described in Algorithm 2 in [1] with `d = 0`
+    ///
+    ///
+    /// [1]: https://eprint.iacr.org/2023/1668
+    fn duplex_overwrite(&mut self, data: &[Felt]) {
+        self.permute();
+
+        let _ = self.squeeze_rate();
+
+        for (idx, &element) in data.iter().enumerate() {
+            self.state[RATE_START + idx] = element;
+        }
+    }
+
+    /// Duplex interface as described in Algorithm 2 in [1] with `d = 1`
+    ///
+    ///
+    /// [1]: https://eprint.iacr.org/2023/1668
+    fn duplex_add(&mut self, data: &[Felt]) -> [Felt; RATE_WIDTH] {
+        self.permute();
+
+        let squeezed_data = self.squeeze_rate();
+
+        for (idx, &element) in data.iter().enumerate() {
+            self.state[RATE_START + idx] += element;
+        }
+
+        squeezed_data
+    }
+
+    /// Squeezes an authentication tag
+    fn squeeze_tag(&mut self) -> AuthTag {
+        self.permute();
+        AuthTag(
+            self.state[RATE_RANGE_FIRST_HALF]
+                .try_into()
+                .expect("failed to convert to array"),
+        )
+    }
+
+    /// Applies the RPO permutation to the sponge state
+    fn permute(&mut self) {
+        Rpo256::apply_permutation(&mut self.state);
+    }
+
+    fn initialize(&mut self, sk: &SecretKey, nonce: &Nonce) {
+        self.state[RATE_RANGE_FIRST_HALF].copy_from_slice(&sk.0);
+        self.state[RATE_RANGE_SECOND_HALF].copy_from_slice(&nonce.0);
+    }
+
+    fn squeeze_rate(&self) -> [Felt; RATE_WIDTH] {
+        self.state[RATE_RANGE].try_into().unwrap()
+    }
+}
+
+// SECRET KEY IMPLEMENTATION
+// ================================================================================================
+
+impl SecretKey {
+    /// Creates a new random secret key using the default random number generator
+    #[cfg(feature = "std")]
+    pub fn new() -> Self {
+        use rand::{SeedableRng, rngs::StdRng};
+        let mut rng = StdRng::from_os_rng();
+
+        Self::with_rng(&mut rng)
+    }
+
+    /// Creates a new random secret key using the provided random number generator
+    pub fn with_rng<R: Rng>(rng: &mut R) -> Self {
+        rng.sample(StandardUniform)
+    }
+
+    /// Encrypts the provided data using this secret key and a random nonce
+    #[cfg(feature = "std")]
+    pub fn encrypt(&self, data: &[Felt]) -> EncryptedData {
+        use rand::{SeedableRng, rngs::StdRng};
+        let mut rng = StdRng::from_os_rng();
+        let nonce = Nonce::with_rng(&mut rng);
+
+        self.encrypt_with_nonce(data, &nonce)
+    }
+
+    /// Encrypts the provided data using this secret key and a specified nonce
+    pub fn encrypt_with_nonce(&self, data: &[Felt], nonce: &Nonce) -> EncryptedData {
+        if data.is_empty() {
+            return EncryptedData::default();
+        }
+        let mut sponge = SpongeState::new();
+
+        // Initialize with key and nonce
+        sponge.initialize(&self, nonce);
+
+        // Encrypt the data
+        let mut ciphertext = Vec::with_capacity(data.len());
+        let mut data_block_iterator = data.chunks_exact(RATE_WIDTH);
+
+        data_block_iterator.by_ref().for_each(|data_block| {
+            let keystream = sponge.duplex_add(data_block);
+            for (i, &plaintext_felt) in data_block.iter().enumerate() {
+                ciphertext.push(plaintext_felt + keystream[i]);
+            }
+        });
+
+        // Finalize and generate authentication tag
+        let final_uneven_block = data_block_iterator.remainder();
+        let final_uneven_ciphertext_block = finalize_encryption(&mut sponge, final_uneven_block);
+        ciphertext.extend_from_slice(&final_uneven_ciphertext_block);
+
+        let auth_tag = sponge.squeeze_tag();
+
+        EncryptedData { ciphertext, auth_tag }
+    }
+
+    /// Decrypts the provided encrypted data using this secret key
+    pub fn decrypt(
+        &self,
+        encrypted_data: &EncryptedData,
+        nonce: &Nonce,
+    ) -> Result<Vec<Felt>, EncryptionError> {
+        let mut sponge = SpongeState::new();
+
+        if encrypted_data.ciphertext.is_empty() {
+            return Ok(vec![]);
+        }
+        assert_eq!(encrypted_data.ciphertext.len() % RATE_WIDTH, 0);
+
+        // Initialize with key and nonce (same as encryption)
+        sponge.initialize(self, nonce);
+
+        // Decrypt the data
+        let mut plaintext = Vec::with_capacity(encrypted_data.ciphertext.len());
+        let mut ciphertext_block_iterator = encrypted_data.ciphertext.chunks_exact(RATE_WIDTH);
+        ciphertext_block_iterator.by_ref().for_each(|ciphertext_data_block| {
+            let keystream = sponge.duplex_add(&[]);
+            for (i, &ciphertext_felt) in ciphertext_data_block.iter().enumerate() {
+                let plaintext_felt = ciphertext_felt - keystream[i];
+                plaintext.push(plaintext_felt);
+            }
+            sponge.state[RATE_RANGE].copy_from_slice(&ciphertext_data_block);
+        });
+
+        // Verify authentication tag
+        let computed_tag = sponge.squeeze_tag();
+        if computed_tag != encrypted_data.auth_tag {
+            return Err(EncryptionError::InvalidAuthTag);
+        }
+
+        // Remove padding
+        unpad(&mut plaintext);
+
+        Ok(plaintext)
+    }
+}
+
+/// Finalizes encryption by performing the padding and encryption of the final block.
+fn finalize_encryption(sponge: &mut SpongeState, remaining_data: &[Felt]) -> Vec<Felt> {
+    let mut ciphertext = Vec::with_capacity(RATE_WIDTH);
+
+    if remaining_data.len() == 0 {
+        let keystream = sponge.duplex_add(&PADDING_BLOCK);
+        for (i, &plaintext_felt) in PADDING_BLOCK.iter().enumerate() {
+            ciphertext.push(plaintext_felt + keystream[i]);
+        }
+    } else {
+        debug_assert!(1 <= remaining_data.len() && remaining_data.len() < RATE_WIDTH);
+        let mut chunk = [ZERO; RATE_WIDTH];
+        remaining_data.iter().enumerate().for_each(|(idx, entry)| chunk[idx] = *entry);
+        chunk[remaining_data.len()] = ONE;
+
+        for i in (remaining_data.len() + 1)..RATE_WIDTH {
+            chunk[i] = ZERO
+        }
+        let keystream = sponge.duplex_add(&chunk);
+        for (i, &plaintext_felt) in chunk.iter().enumerate() {
+            ciphertext.push(plaintext_felt + keystream[i]);
+        }
+    }
+
+    ciphertext
+}
+
+/// Removes the padding from the decoded ciphertext.
+fn unpad(plaintext: &mut Vec<Felt>) {
+    let (num_blocks, remainder) = plaintext.len().div_rem(&RATE_WIDTH);
+    assert_eq!(remainder, 0);
+
+    let final_block: &[Felt; RATE_WIDTH] = plaintext.last_chunk().expect("plaintext is empty");
+
+    let position = final_block
+        .iter()
+        .rposition(|entry| *entry == ONE)
+        .expect("padding with ONE is missing");
+
+    plaintext.truncate((num_blocks - 1) * RATE_WIDTH + position);
+}
+
+impl Distribution<SecretKey> for StandardUniform {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> SecretKey {
+        let mut res = [ZERO; SECRET_KEY_SIZE];
+        let uni_dist =
+            Uniform::new(0, Felt::MODULUS).expect("should not fail given the size of the field");
+        for r in res.iter_mut() {
+            let sampled_integer = uni_dist.sample(rng);
+            *r = Felt::new(sampled_integer);
+        }
+        SecretKey(res)
+    }
+}
+
+// NONCE IMPLEMENTATION
+// ================================================================================================
+
+impl Nonce {
+    /// Creates a new random nonce using the provided random number generator
+    pub fn with_rng<R: Rng>(rng: &mut R) -> Self {
+        rng.sample(StandardUniform)
+    }
+}
+
+impl Distribution<Nonce> for StandardUniform {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Nonce {
+        let mut res = [ZERO; NONCE_SIZE];
+        let uni_dist =
+            Uniform::new(0, Felt::MODULUS).expect("should not fail given the size of the field");
+        for r in res.iter_mut() {
+            let sampled_integer = uni_dist.sample(rng);
+            *r = Felt::new(sampled_integer);
+        }
+        Nonce(res)
+    }
+}
+
+// ERROR TYPES
+// ================================================================================================
+
+/// Errors that can occur during encryption/decryption operations
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncryptionError {
+    /// Authentication tag verification failed
+    InvalidAuthTag,
+}
+
+impl fmt::Display for EncryptionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EncryptionError::InvalidAuthTag => write!(f, "Authentication tag verification failed"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for EncryptionError {}

--- a/miden-crypto/src/encryption/mod.rs
+++ b/miden-crypto/src/encryption/mod.rs
@@ -28,6 +28,9 @@ pub const AUTH_TAG_SIZE: usize = 4;
 /// Size of the sponge state field elements
 const STATE_WIDTH: usize = Rpo256::STATE_WIDTH;
 
+/// Capacity portion of the sponge state.
+const CAPACITY_RANGE: Range<usize> = Rpo256::CAPACITY_RANGE;
+
 /// Rate portion of the sponge state
 const RATE_RANGE: Range<usize> = Rpo256::RATE_RANGE;
 
@@ -223,8 +226,10 @@ impl SpongeState {
     fn duplex_overwrite(&mut self, data: &[Felt]) {
         self.permute();
 
-        let _ = self.squeeze_rate();
+        // add 1 to the first capacity element
+        self.state[CAPACITY_RANGE.start] += ONE;
 
+        // overwrite the rate portion with `data`
         for (idx, &element) in data.iter().enumerate() {
             self.state[RATE_START + idx] = element;
         }

--- a/miden-crypto/src/encryption/mod.rs
+++ b/miden-crypto/src/encryption/mod.rs
@@ -136,7 +136,7 @@ impl SecretKey {
         });
 
         // Encrypt the data
-        let mut ciphertext = Vec::with_capacity(data.len());
+        let mut ciphertext = Vec::with_capacity(data.len() + RATE_WIDTH);
         let mut data_block_iterator = data.chunks_exact(RATE_WIDTH);
 
         data_block_iterator.by_ref().for_each(|data_block| {

--- a/miden-crypto/src/encryption/test.rs
+++ b/miden-crypto/src/encryption/test.rs
@@ -1,0 +1,308 @@
+use super::*;
+use proptest::{
+    prelude::{any, prop},
+    prop_assert_eq, prop_assert_ne, prop_assume, proptest,
+};
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+
+// PROPERTY-BASED TESTS
+// ================================================================================================
+
+proptest! {
+    #[test]
+    fn test_encryption_decryption_roundtrip(
+        seed in any::<u64>(),
+        data_len in 1usize..100,
+    ) {
+        let mut rng = ChaCha20Rng::seed_from_u64(seed);
+        let key = SecretKey::with_rng(&mut rng);
+        let nonce = Nonce::with_rng(&mut rng);
+
+        // Generate random field elements
+        let data: Vec<Felt> = (0..data_len)
+            .map(|_| Felt::new(rng.next_u64()))
+            .collect();
+
+        let encrypted = key.encrypt_with_nonce(&data, &nonce);
+        let decrypted = key.decrypt(&encrypted, &nonce).unwrap();
+
+        prop_assert_eq!(data, decrypted);
+    }
+
+    #[test]
+    fn test_different_keys_different_outputs(
+        seed1 in any::<u64>(),
+        seed2 in any::<u64>(),
+        data in prop::collection::vec(any::<u64>(), 1..50),
+    ) {
+        prop_assume!(seed1 != seed2);
+
+        let mut rng1 = ChaCha20Rng::seed_from_u64(seed1);
+        let mut rng2 = ChaCha20Rng::seed_from_u64(seed2);
+
+        let key1 = SecretKey::with_rng(&mut rng1);
+        let key2 = SecretKey::with_rng(&mut rng2);
+        let nonce = Nonce::with_rng(&mut rng1);
+
+        let data: Vec<Felt> = data.into_iter()
+            .map(|x| Felt::new(x))
+            .collect();
+
+        let encrypted1 = key1.encrypt_with_nonce(&data, &nonce);
+        let encrypted2 = key2.encrypt_with_nonce(&data, &nonce);
+
+        // Different keys should produce different ciphertexts
+        prop_assert_ne!(encrypted1.ciphertext, encrypted2.ciphertext);
+        prop_assert_ne!(encrypted1.auth_tag, encrypted2.auth_tag);
+    }
+
+    #[test]
+    fn test_different_nonces_different_outputs(
+        seed in any::<u64>(),
+        data in prop::collection::vec(any::<u64>(), 1..50),
+    ) {
+        let mut rng = ChaCha20Rng::seed_from_u64(seed);
+        let key = SecretKey::with_rng(&mut rng);
+        let nonce1 = Nonce::with_rng(&mut rng);
+        let nonce2 = Nonce::with_rng(&mut rng);
+
+        let data: Vec<Felt> = data.into_iter()
+            .map(|x| Felt::new(x ))
+            .collect();
+
+        let encrypted1 = key.encrypt_with_nonce(&data, &nonce1);
+        let encrypted2 = key.encrypt_with_nonce(&data, &nonce2);
+
+        // Different nonces should produce different ciphertexts (with very high probability)
+        if nonce1 != nonce2 {
+            prop_assert_ne!(encrypted1.ciphertext, encrypted2.ciphertext);
+            prop_assert_ne!(encrypted1.auth_tag, encrypted2.auth_tag);
+        }
+    }
+}
+
+// UNIT TESTS
+// ================================================================================================
+
+#[test]
+fn test_secret_key_creation() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let key1 = SecretKey::with_rng(&mut rng);
+    let key2 = SecretKey::with_rng(&mut rng);
+
+    // Keys should be different
+    assert_ne!(key1, key2);
+}
+
+#[test]
+fn test_nonce_creation() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let nonce1 = Nonce::with_rng(&mut rng);
+    let nonce2 = Nonce::with_rng(&mut rng);
+
+    // Nonces should be different
+    assert_ne!(nonce1, nonce2);
+}
+
+#[test]
+fn test_empty_data_encryption() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    let empty_data: Vec<Felt> = vec![];
+    let encrypted = key.encrypt_with_nonce(&empty_data, &nonce);
+    let decrypted = key.decrypt(&encrypted, &nonce).unwrap();
+
+    assert_eq!(empty_data, decrypted);
+    assert!(encrypted.ciphertext.is_empty());
+}
+
+#[test]
+fn test_single_element_encryption() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    let data = vec![Felt::new(42)];
+    let encrypted = key.encrypt_with_nonce(&data, &nonce);
+    let decrypted = key.decrypt(&encrypted, &nonce).unwrap();
+
+    assert_eq!(data, decrypted);
+    assert_eq!(encrypted.ciphertext.len(), 8);
+}
+
+#[test]
+fn test_large_data_encryption() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    // Test with data larger than rate
+    let data: Vec<Felt> = (0..100).map(|i| Felt::new(i as u64)).collect();
+
+    let encrypted = key.encrypt_with_nonce(&data, &nonce);
+    let decrypted = key.decrypt(&encrypted, &nonce).unwrap();
+
+    assert_eq!(data, decrypted);
+}
+
+#[test]
+fn test_encryption_various_lengths() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    for len in [1, 7, 8, 9, 15, 16, 17, 31, 32, 35, 39, 54, 67, 100, 1000] {
+        let data: Vec<Felt> = (0..len).map(|i| Felt::new(i as u64)).collect();
+
+        let encrypted = key.encrypt_with_nonce(&data, &nonce);
+        let decrypted = key.decrypt(&encrypted, &nonce).unwrap();
+
+        assert_eq!(data, decrypted, "Failed for length {}", len);
+    }
+}
+
+#[test]
+fn test_ciphertext_tampering_detection() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    let data = vec![Felt::new(123), Felt::new(456)];
+    let mut encrypted = key.encrypt_with_nonce(&data, &nonce);
+
+    // Tamper with ciphertext
+    encrypted.ciphertext[0] += ONE;
+
+    let result = key.decrypt(&encrypted, &nonce);
+    assert!(matches!(result, Err(EncryptionError::InvalidAuthTag)));
+}
+
+#[test]
+fn test_auth_tag_tampering_detection() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    let data = vec![Felt::new(123), Felt::new(456)];
+    let mut encrypted = key.encrypt_with_nonce(&data, &nonce);
+
+    // Tamper with auth tag
+    let mut tampered_tag = encrypted.auth_tag.0;
+    tampered_tag[0] += ONE;
+    encrypted.auth_tag = AuthTag(tampered_tag);
+
+    let result = key.decrypt(&encrypted, &nonce);
+    assert!(matches!(result, Err(EncryptionError::InvalidAuthTag)));
+}
+
+#[test]
+fn test_wrong_key_detection() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let key1 = SecretKey::with_rng(&mut rng);
+    let key2 = SecretKey::with_rng(&mut rng);
+    let nonce = Nonce::with_rng(&mut rng);
+
+    let data = vec![Felt::new(123), Felt::new(456)];
+    let encrypted = key1.encrypt_with_nonce(&data, &nonce);
+
+    // Try to decrypt with wrong key
+    let result = key2.decrypt(&encrypted, &nonce);
+    assert!(matches!(result, Err(EncryptionError::InvalidAuthTag)));
+}
+
+#[test]
+fn test_wrong_nonce_detection() {
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    let key = SecretKey::with_rng(&mut rng);
+    let nonce1 = Nonce::with_rng(&mut rng);
+    let nonce2 = Nonce::with_rng(&mut rng);
+
+    let data = vec![Felt::new(123), Felt::new(456)];
+    let encrypted = key.encrypt_with_nonce(&data, &nonce1);
+
+    // Try to decrypt with wrong nonce
+    let result = key.decrypt(&encrypted, &nonce2);
+    assert!(matches!(result, Err(EncryptionError::InvalidAuthTag)));
+}
+
+// SECURITY TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod security_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_key_uniqueness() {
+        let seed = [0_u8; 32];
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let mut keys = HashSet::new();
+
+        // Generate 1000 keys and ensure they're all unique
+        for _ in 0..1000 {
+            let key = SecretKey::with_rng(&mut rng);
+            let key_bytes = format!("{:?}", key.0);
+            assert!(keys.insert(key_bytes), "Duplicate key generated!");
+        }
+    }
+
+    #[test]
+    fn test_nonce_uniqueness() {
+        let seed = [0_u8; 32];
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let mut nonces = HashSet::new();
+
+        // Generate 1000 nonces and ensure they're all unique
+        for _ in 0..1000 {
+            let nonce = Nonce::with_rng(&mut rng);
+            let nonce_bytes = format!("{:?}", nonce.0);
+            assert!(nonces.insert(nonce_bytes), "Duplicate nonce generated!");
+        }
+    }
+
+    #[test]
+    fn test_ciphertext_appears_random() {
+        let seed = [0_u8; 32];
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let key = SecretKey::with_rng(&mut rng);
+
+        // Encrypt the same plaintext with different nonces
+        let plaintext = vec![ZERO; 10]; // All zeros
+        let mut ciphertexts = Vec::new();
+
+        for _ in 0..100 {
+            let nonce = Nonce::with_rng(&mut rng);
+            let encrypted = key.encrypt_with_nonce(&plaintext, &nonce);
+            ciphertexts.push(encrypted.ciphertext);
+        }
+
+        // Ensure all ciphertexts are different (randomness test)
+        for i in 0..ciphertexts.len() {
+            for j in i + 1..ciphertexts.len() {
+                assert_ne!(
+                    ciphertexts[i], ciphertexts[j],
+                    "Ciphertexts {} and {} are identical!",
+                    i, j
+                );
+            }
+        }
+    }
+}

--- a/miden-crypto/src/lib.rs
+++ b/miden-crypto/src/lib.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod dsa;
+pub mod encryption;
 pub mod hash;
 pub mod merkle;
 pub mod rand;


### PR DESCRIPTION
## Describe your changes

Addresses #476 

The main complexity is coming from the padding rule used. Things could be simplified a bit if we are willing to pad the plaintext before starting the main encryption loop, similar to how it is now done for the associated data. The main issue with this is the extra allocation which I am not sure how to avoid easily.

Includes also some benchmarks, where I am logging a modest `5mb/s` on my modest machine for both encryption and decryption.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
