### PR TITLE
Rename ValuePath to MerkleProof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [BREAKING] Modified the public key in Falcon DSA to be the polynomial instead of the commitment ([#460](https://github.com/0xMiden/crypto/pull/460)).
 - [BREAKING] Use `SparseMerklePath` in SMT proofs for better memory efficiency ([#477](https://github.com/0xMiden/crypto/pull/477)).
 - [BREAKING] Rename `SparseValuePath` to `SimpleSmtProof` ([#477](https://github.com/0xMiden/crypto/pull/477)).
+- [BREAKING] Rename `ValuePath` to `MerkleProof`.
 
 # 0.15.9 (2025-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [BREAKING] Modified the public key in Falcon DSA to be the polynomial instead of the commitment ([#460](https://github.com/0xMiden/crypto/pull/460)).
 - [BREAKING] Use `SparseMerklePath` in SMT proofs for better memory efficiency ([#477](https://github.com/0xMiden/crypto/pull/477)).
 - [BREAKING] Rename `SparseValuePath` to `SimpleSmtProof` ([#477](https://github.com/0xMiden/crypto/pull/477)).
-- [BREAKING] Rename `ValuePath` to `MerkleProof`.
+- [BREAKING] Rename `ValuePath` to `MerkleProof` ([#483](https://github.com/0xMiden/crypto/pull/483)).
 
 # 0.15.9 (2025-07-24)
 

--- a/miden-crypto/src/merkle/mod.rs
+++ b/miden-crypto/src/merkle/mod.rs
@@ -16,7 +16,7 @@ mod merkle_tree;
 pub use merkle_tree::{MerkleTree, path_to_text, tree_to_text};
 
 mod path;
-pub use path::{MerklePath, RootPath, ValuePath};
+pub use path::{MerklePath, MerkleProof, RootPath};
 
 mod sparse_path;
 pub use sparse_path::SparseMerklePath;

--- a/miden-crypto/src/merkle/partial_mt/mod.rs
+++ b/miden-crypto/src/merkle/partial_mt/mod.rs
@@ -6,7 +6,7 @@ use alloc::{
 use core::fmt;
 
 use super::{
-    EMPTY_WORD, InnerNodeInfo, MerkleError, MerklePath, NodeIndex, Rpo256, ValuePath, Word,
+    EMPTY_WORD, InnerNodeInfo, MerkleError, MerklePath, MerkleProof, NodeIndex, Rpo256, Word,
 };
 use crate::utils::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, word_to_hex,
@@ -196,12 +196,12 @@ impl PartialMerkleTree {
     }
 
     /// Returns a vector of paths from every leaf to the root.
-    pub fn to_paths(&self) -> Vec<(NodeIndex, ValuePath)> {
+    pub fn to_paths(&self) -> Vec<(NodeIndex, MerkleProof)> {
         let mut paths = Vec::new();
         self.leaves.iter().for_each(|&leaf| {
             paths.push((
                 leaf,
-                ValuePath {
+                MerkleProof {
                     value: self.get_node(leaf).expect("Failed to get leaf node"),
                     path: self.get_path(leaf).expect("Failed to get path"),
                 },

--- a/miden-crypto/src/merkle/partial_mt/tests.rs
+++ b/miden-crypto/src/merkle/partial_mt/tests.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 
 use super::{
     super::{MerkleStore, MerkleTree, NodeIndex, PartialMerkleTree, int_to_node},
-    Deserializable, InnerNodeInfo, Serializable, ValuePath, Word,
+    Deserializable, InnerNodeInfo, MerkleProof, Serializable, Word,
 };
 
 // TEST DATA
@@ -209,12 +209,12 @@ fn get_paths() {
     // for each leaf.
 
     let leaves = [NODE20, NODE22, NODE23, NODE32, NODE33];
-    let expected_paths: Vec<(NodeIndex, ValuePath)> = leaves
+    let expected_paths: Vec<(NodeIndex, MerkleProof)> = leaves
         .iter()
         .map(|&leaf| {
             (
                 leaf,
-                ValuePath {
+                MerkleProof {
                     value: mt.get_node(leaf).unwrap(),
                     path: mt.get_path(leaf).unwrap(),
                 },

--- a/miden-crypto/src/merkle/path.rs
+++ b/miden-crypto/src/merkle/path.rs
@@ -203,23 +203,23 @@ impl Iterator for InnerNodeIterator<'_> {
 
 /// A container for a [crate::Word] value and its [MerklePath] opening.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct ValuePath {
+pub struct MerkleProof {
     /// The node value opening for `path`.
     pub value: Word,
     /// The path from `value` to `root` (exclusive).
     pub path: MerklePath,
 }
 
-impl ValuePath {
-    /// Returns a new [ValuePath] instantiated from the specified value and path.
+impl MerkleProof {
+    /// Returns a new [MerkleProof] instantiated from the specified value and path.
     pub fn new(value: Word, path: MerklePath) -> Self {
         Self { value, path }
     }
 }
 
-impl From<(MerklePath, Word)> for ValuePath {
+impl From<(MerklePath, Word)> for MerkleProof {
     fn from((path, value): (MerklePath, Word)) -> Self {
-        ValuePath::new(value, path)
+        MerkleProof::new(value, path)
     }
 }
 
@@ -254,14 +254,14 @@ impl Deserializable for MerklePath {
     }
 }
 
-impl Serializable for ValuePath {
+impl Serializable for MerkleProof {
     fn write_into<W: winter_utils::ByteWriter>(&self, target: &mut W) {
         self.value.write_into(target);
         self.path.write_into(target);
     }
 }
 
-impl Deserializable for ValuePath {
+impl Deserializable for MerkleProof {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let value = Word::read_from(source)?;
         let path = MerklePath::read_from(source)?;

--- a/miden-crypto/src/merkle/smt/simple/proof.rs
+++ b/miden-crypto/src/merkle/smt/simple/proof.rs
@@ -1,6 +1,6 @@
 use crate::{
     Word,
-    merkle::{MerkleError, SparseMerklePath, ValuePath},
+    merkle::{MerkleError, MerkleProof, SparseMerklePath},
 };
 
 /// A container for a [crate::Word] value and its [SparseMerklePath] opening.
@@ -28,34 +28,34 @@ impl From<(SparseMerklePath, Word)> for SimpleSmtProof {
     }
 }
 
-impl TryFrom<ValuePath> for SimpleSmtProof {
+impl TryFrom<MerkleProof> for SimpleSmtProof {
     type Error = MerkleError;
 
     /// # Errors
     ///
     /// This conversion returns [MerkleError::DepthTooBig] if the path length is greater than
     /// [`super::SMT_MAX_DEPTH`].
-    fn try_from(other: ValuePath) -> Result<Self, MerkleError> {
-        let ValuePath { value, path } = other;
+    fn try_from(other: MerkleProof) -> Result<Self, MerkleError> {
+        let MerkleProof { value, path } = other;
         let path = SparseMerklePath::try_from(path)?;
         Ok(SimpleSmtProof { value, path })
     }
 }
 
-impl From<SimpleSmtProof> for ValuePath {
+impl From<SimpleSmtProof> for MerkleProof {
     fn from(other: SimpleSmtProof) -> Self {
         let SimpleSmtProof { value, path } = other;
-        ValuePath { value, path: path.into() }
+        MerkleProof { value, path: path.into() }
     }
 }
 
-impl PartialEq<ValuePath> for SimpleSmtProof {
-    fn eq(&self, rhs: &ValuePath) -> bool {
+impl PartialEq<MerkleProof> for SimpleSmtProof {
+    fn eq(&self, rhs: &MerkleProof) -> bool {
         self.value == rhs.value && self.path == rhs.path
     }
 }
 
-impl PartialEq<SimpleSmtProof> for ValuePath {
+impl PartialEq<SimpleSmtProof> for MerkleProof {
     fn eq(&self, rhs: &SimpleSmtProof) -> bool {
         rhs == self
     }

--- a/miden-crypto/src/merkle/store/mod.rs
+++ b/miden-crypto/src/merkle/store/mod.rs
@@ -2,8 +2,8 @@ use alloc::vec::Vec;
 use core::borrow::Borrow;
 
 use super::{
-    EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, MerkleTree, NodeIndex,
-    PartialMerkleTree, RootPath, Rpo256, SimpleSmt, Smt, ValuePath, Word, mmr::Mmr,
+    EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, MerkleProof, MerkleTree, NodeIndex,
+    PartialMerkleTree, RootPath, Rpo256, SimpleSmt, Smt, Word, mmr::Mmr,
 };
 use crate::{
     Map,
@@ -151,7 +151,7 @@ impl MerkleStore {
     /// - `RootNotInStore` if the `root` is not present in the store.
     /// - `NodeNotInStore` if a node needed to traverse from `root` to `index` is not present in the
     ///   store.
-    pub fn get_path(&self, root: Word, index: NodeIndex) -> Result<ValuePath, MerkleError> {
+    pub fn get_path(&self, root: Word, index: NodeIndex) -> Result<MerkleProof, MerkleError> {
         let mut hash = root;
         let mut path = Vec::with_capacity(index.depth().into());
 
@@ -177,7 +177,7 @@ impl MerkleStore {
         // the path is computed from root to leaf, so it must be reversed
         path.reverse();
 
-        Ok(ValuePath::new(hash, MerklePath::new(path)))
+        Ok(MerkleProof::new(hash, MerklePath::new(path)))
     }
 
     // LEAF TRAVERSAL
@@ -430,7 +430,7 @@ impl MerkleStore {
         value: Word,
     ) -> Result<RootPath, MerkleError> {
         let node = value;
-        let ValuePath { value, path } = self.get_path(root, index)?;
+        let MerkleProof { value, path } = self.get_path(root, index)?;
 
         // performs the update only if the node value differs from the opening
         if node != value {


### PR DESCRIPTION
[Followup from #477:](https://github.com/0xMiden/crypto/pull/477#discussion_r2270774488):
> We could also rename ValuePath into MerkleProof to be consistent with the other ones - but that's for a different PR.