### PR TITLE
feat: extra getters for `InnerNode` and `NodeIndex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Validate `NodeIndex` depth ([#482](https://github.com/0xMiden/crypto/pull/482)).
 - [BREAKING] Rename `ValuePath` to `MerkleProof` ([#483](https://github.com/0xMiden/crypto/pull/483)).
 - Added an implementation of Keccak256 hash function ([#487](https://github.com/0xMiden/crypto/pull/487)).
+- Added `{Smt,PartialSmt}::inner_node_indices` to make inner nodes accessible ([#494](https://github.com/0xMiden/crypto/pull/494)).
 
 # 0.15.9 (2025-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.1 (TBD)
+
+- Added `{Smt,PartialSmt}::inner_node_indices` to make inner nodes accessible ([#494](https://github.com/0xMiden/crypto/pull/494)).
+
 ## 0.16.0 (2025-08-15)
 
 - [BREAKING] Incremented MSRV to 1.88.
@@ -15,7 +19,6 @@
 - Validate `NodeIndex` depth ([#482](https://github.com/0xMiden/crypto/pull/482)).
 - [BREAKING] Rename `ValuePath` to `MerkleProof` ([#483](https://github.com/0xMiden/crypto/pull/483)).
 - Added an implementation of Keccak256 hash function ([#487](https://github.com/0xMiden/crypto/pull/487)).
-- Added `{Smt,PartialSmt}::inner_node_indices` to make inner nodes accessible ([#494](https://github.com/0xMiden/crypto/pull/494)).
 
 # 0.15.9 (2025-07-24)
 

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -254,8 +254,7 @@ impl Smt {
         })
     }
 
-    /// Returns an iterator over the [`InnerNode`] and the respective [`NodeIndex`] of the
-    /// [`Smt`].
+    /// Returns an iterator over the [`InnerNode`] and the respective [`NodeIndex`] of the [`Smt`].
     pub fn inner_node_indices(&self) -> impl Iterator<Item = (NodeIndex, InnerNode)> + '_ {
         self.inner_nodes.iter().map(|(idx, inner)| (*idx, inner.clone()))
     }

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -255,7 +255,7 @@ impl Smt {
     }
 
     /// Returns an iterator over the [`InnerNode`] and the respective [`NodeIndex`] of the
-    /// [`PartialSmt`].
+    /// [`Smt`].
     pub fn inner_node_indices(&self) -> impl Iterator<Item = (NodeIndex, InnerNode)> + '_ {
         self.inner_nodes.iter().map(|(idx, inner)| (*idx, inner.clone()))
     }

--- a/miden-crypto/src/merkle/smt/full/mod.rs
+++ b/miden-crypto/src/merkle/smt/full/mod.rs
@@ -254,6 +254,12 @@ impl Smt {
         })
     }
 
+    /// Returns an iterator over the [`InnerNode`] and the respective [`NodeIndex`] of the
+    /// [`PartialSmt`].
+    pub fn inner_node_indices(&self) -> impl Iterator<Item = (NodeIndex, InnerNode)> + '_ {
+        self.inner_nodes.iter().map(|(idx, inner)| (*idx, inner.clone()))
+    }
+
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 

--- a/miden-crypto/src/merkle/smt/partial.rs
+++ b/miden-crypto/src/merkle/smt/partial.rs
@@ -246,6 +246,12 @@ impl PartialSmt {
         self.0.inner_nodes()
     }
 
+    /// Returns an iterator over the [`InnerNode`] and the respective [`NodeIndex`] of the
+    /// [`PartialSmt`].
+    pub fn inner_node_indicies(&self) -> impl Iterator<Item = (NodeIndex, InnerNode)> + '_ {
+        self.0.inner_node_indices()
+    }
+
     /// Returns an iterator over the tracked, non-empty leaves of the [`PartialSmt`] in arbitrary
     /// order.
     pub fn leaves(&self) -> impl Iterator<Item = (LeafIndex<SMT_DEPTH>, &SmtLeaf)> {


### PR DESCRIPTION
## Describe your changes

Expose extra getters for inner nodes, to allow to reconstruct a compressed `PartialSmt` from protobuf messages, see https://github.com/0xMiden/miden-node/pull/1158

I might be doing something wrong here, so I'd very much appreciate an alternative to the above, if such exists. I didn't find a way to access the unterlyding `InnerNode`s via `PartialSmt`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
