### PR TITLE
Remove redundant length checks after read_array in SecretKey deserialization

### DIFF
--- a/miden-crypto/src/dsa/rpo_falcon512/keys/secret_key.rs
+++ b/miden-crypto/src/dsa/rpo_falcon512/keys/secret_key.rs
@@ -302,11 +302,6 @@ impl Deserializable for SecretKey {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let byte_vector: [u8; SK_LEN] = source.read_array()?;
 
-        // check length
-        if byte_vector.len() < 2 {
-            return  Err(DeserializationError::InvalidValue("Invalid encoding length: Failed to decode as length is different from the one expected".to_string()));
-        }
-
         // read fields
         let header = byte_vector[0];
 
@@ -326,9 +321,6 @@ impl Deserializable for SecretKey {
             ));
         }
 
-        if byte_vector.len() != SK_LEN {
-            return Err(DeserializationError::InvalidValue("Invalid encoding length: Failed to decode as length is different from the one expected".to_string()));
-        }
 
         let chunk_size_f = ((n * WIDTH_SMALL_POLY_COEFFICIENT) + 7) >> 3;
         let chunk_size_g = ((n * WIDTH_SMALL_POLY_COEFFICIENT) + 7) >> 3;


### PR DESCRIPTION
- Drop unnecessary len() < 2 and len() != SK_LEN checks after read_array::<SK_LEN>()? in miden-crypto/src/dsa/rpo_falcon512/keys/secret_key.rs.
- read_array::<N>() already guarantees exact-size reads (or errors), so post-checks add no safety.
- Aligns SecretKey deserialization style with PublicKey and SignaturePoly which rely on read_array::<N>() guarantees.