### PR TITLE
fix: `benchmark_rand_core!` not calling `b.iter()` properly

### DIFF
--- a/miden-crypto/benches/common/macros.rs
+++ b/miden-crypto/benches/common/macros.rs
@@ -344,7 +344,7 @@ macro_rules! benchmark_rand_core {
                     BenchmarkId::new($operation, count),
                     &count,
                     |b: &mut criterion::Bencher, &count_param: &usize| {
-                        $closure(b, &mut coin, count_param)
+                        b.iter(|| $closure(&mut coin, count_param))
                     },
                 );
 

--- a/miden-crypto/benches/rand.rs
+++ b/miden-crypto/benches/rand.rs
@@ -51,7 +51,7 @@ benchmark_rand_draw!(
     TEST_SEED,
     "draw_element",
     PRNG_OUTPUT_SIZES,
-    |_b, coin: &mut RpoRandomCoin, count| {
+    |coin: &mut RpoRandomCoin, count| {
         for _ in 0..count {
             let _element = coin.draw_element();
         }
@@ -63,7 +63,7 @@ benchmark_rand_draw!(
     TEST_SEED,
     "draw_word",
     PRNG_OUTPUT_SIZES,
-    |_b, coin: &mut RpoRandomCoin, count| {
+    |coin: &mut RpoRandomCoin, count| {
         for _ in 0..count {
             let _word = coin.draw_word();
         }
@@ -89,7 +89,7 @@ benchmark_rand_draw!(
     TEST_SEED,
     "draw_element",
     PRNG_OUTPUT_SIZES,
-    |_b, coin: &mut RpxRandomCoin, count| {
+    |coin: &mut RpxRandomCoin, count| {
         for _ in 0..count {
             let _element = coin.draw_element();
         }
@@ -101,7 +101,7 @@ benchmark_rand_draw!(
     TEST_SEED,
     "draw_word",
     PRNG_OUTPUT_SIZES,
-    |_b, coin: &mut RpxRandomCoin, count| {
+    |coin: &mut RpxRandomCoin, count| {
         for _ in 0..count {
             let _word = coin.draw_word();
         }


### PR DESCRIPTION
Follow-up to #503 fixing one macro not using its closure properly. 🤦‍♂️ 
