### PR TITLE
chore: reuse shared lint workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,35 +9,5 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  clippy:
-    name: clippy nightly on ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - name: Clippy
-        run: |
-          rustup update --no-self-update nightly
-          rustup +nightly component add clippy
-          make clippy
-
-  rustfmt:
-    name: rustfmt check nightly on ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - name: Rustfmt
-        run: |
-          rustup update --no-self-update nightly
-          rustup default ${{ matrix.toolchain }}
-          rustup +nightly component add rustfmt
-          make format-check
-
-  doc:
-    name: doc stable on ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@main
-      - name: Build docs
-        run: |
-          rustup update --no-self-update
-          make doc
+  lint:
+    uses: 0xMiden/.github/.github/workflows/lint.yml@main


### PR DESCRIPTION
## Describe your changes
- reuse the workflow file from https://github.com/0xMiden/.github/blob/main/.github/workflows/lint.yml
- effectively adds `typos`, `toml`, `workspace-lints` and `unused_deps` jobs

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
