### PR TITLE
Make `SmtLeaf::entries()` return an iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.17.0 (TBD)
 
-- Added XChaCha20-Poly1305 AEAD scheme ([#484](https://github.com/0xMiden/crypto/pull/484))
+- added arithmetization oriented authenticated encryption with associated data (AEAD) scheme ([#480](https://github.com/0xMiden/crypto/pull/480)).
+- Added XChaCha20-Poly1305 AEAD scheme ([#484](https://github.com/0xMiden/crypto/pull/484)).
+- [BREAKING] `SmtLeaf::entries()` now returns an iterator ([#521](https://github.com/0xMiden/crypto/pull/521)).
 
 ## 0.16.1 (2025-08-21)
 
@@ -26,7 +28,6 @@
 - Validate `NodeIndex` depth ([#482](https://github.com/0xMiden/crypto/pull/482)).
 - [BREAKING] Rename `ValuePath` to `MerkleProof` ([#483](https://github.com/0xMiden/crypto/pull/483)).
 - Added an implementation of Keccak256 hash function ([#487](https://github.com/0xMiden/crypto/pull/487)).
--  Arithmetization oriented authenticated encryption with associated data (AEAD) ([#480](https://github.com/0xMiden/crypto/pull/480)) 
 
 # 0.15.9 (2025-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - added arithmetization oriented authenticated encryption with associated data (AEAD) scheme ([#480](https://github.com/0xMiden/crypto/pull/480)).
 - Added XChaCha20-Poly1305 AEAD scheme ([#484](https://github.com/0xMiden/crypto/pull/484)).
-- [BREAKING] `SmtLeaf::entries()` now returns an iterator ([#521](https://github.com/0xMiden/crypto/pull/521)).
+- [BREAKING] `SmtLeaf::entries()` now returns a slice ([#521](https://github.com/0xMiden/crypto/pull/521)).
 
 ## 0.16.1 (2025-08-21)
 

--- a/miden-crypto/src/merkle/smt/full/leaf.rs
+++ b/miden-crypto/src/merkle/smt/full/leaf.rs
@@ -158,7 +158,7 @@ impl SmtLeaf {
     // ITERATORS
     // ---------------------------------------------------------------------------------------------
 
-    /// Returns an iterator over the key-value pairs in the leaf.
+    /// Returns a slice with key-value pairs in the leaf.
     pub fn entries(&self) -> &[(Word, Word)] {
         match self {
             SmtLeaf::Empty(_) => &[],

--- a/miden-crypto/src/merkle/smt/full/leaf.rs
+++ b/miden-crypto/src/merkle/smt/full/leaf.rs
@@ -158,12 +158,12 @@ impl SmtLeaf {
     // ITERATORS
     // ---------------------------------------------------------------------------------------------
 
-    /// Returns the key-value pairs in the leaf
-    pub fn entries(&self) -> Vec<&(Word, Word)> {
+    /// Returns an iterator over the key-value pairs in the leaf.
+    pub fn entries(&self) -> impl Iterator<Item = &(Word, Word)> {
         match self {
-            SmtLeaf::Empty(_) => Vec::new(),
-            SmtLeaf::Single(kv_pair) => vec![kv_pair],
-            SmtLeaf::Multiple(kv_pairs) => kv_pairs.iter().collect(),
+            SmtLeaf::Empty(_) => [].iter(),
+            SmtLeaf::Single(kv_pair) => core::slice::from_ref(kv_pair).iter(),
+            SmtLeaf::Multiple(kv_pairs) => kv_pairs.iter(),
         }
     }
 

--- a/miden-crypto/src/merkle/smt/full/leaf.rs
+++ b/miden-crypto/src/merkle/smt/full/leaf.rs
@@ -159,11 +159,11 @@ impl SmtLeaf {
     // ---------------------------------------------------------------------------------------------
 
     /// Returns an iterator over the key-value pairs in the leaf.
-    pub fn entries(&self) -> impl Iterator<Item = &(Word, Word)> {
+    pub fn entries(&self) -> &[(Word, Word)] {
         match self {
-            SmtLeaf::Empty(_) => [].iter(),
-            SmtLeaf::Single(kv_pair) => core::slice::from_ref(kv_pair).iter(),
-            SmtLeaf::Multiple(kv_pairs) => kv_pairs.iter(),
+            SmtLeaf::Empty(_) => &[],
+            SmtLeaf::Single(kv_pair) => core::slice::from_ref(kv_pair),
+            SmtLeaf::Multiple(kv_pairs) => kv_pairs,
         }
     }
 


### PR DESCRIPTION
This small PR refactors `SmtLeaf::entries()` method to return an iterator rather than a vector.
