### PR TITLE
implement an Smt with a `HistoricalView` to look back 

### DIFF
--- a/miden-crypto/src/merkle/smt/historical/mod.rs
+++ b/miden-crypto/src/merkle/smt/historical/mod.rs
@@ -1,0 +1,468 @@
+// TODO: avoid all mutable borrows, it's needed due to cache, but we should be able to share the
+// cache over multiple instances for a single one
+
+use core::cell::RefCell;
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    vec::Vec,
+};
+
+use crate::{
+    EMPTY_WORD, Word,
+    hash::rpo::Rpo256,
+    merkle::{
+        InnerNode, LeafIndex, MerklePath, MutationSet, NodeIndex, SMT_DEPTH, Smt, SmtLeaf,
+        SmtProof, SparseMerklePath, smt::SparseMerkleTree,
+    },
+};
+
+mod tests;
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[error("fail: {0}")]
+pub struct OverlayError(&'static str);
+
+// essentially a MutationSet<SMT_DEPTH, Word, Word>;
+#[derive(Debug, Clone)]
+pub struct Overlay {
+    old_root: Word,
+    new_root: Word,
+    // key to SmtLeaf (the hash of that is the value, I think)
+    mutated: HashMap<Word, SmtLeaf>,
+
+    // a lookup to see which intermediate nodes must be recalculated
+    poisoned_tree_leaves: Vec<LeafIndex<SMT_DEPTH>>,
+}
+
+impl Overlay {
+    // XXX scales linearly with `poisoned_tree_leaves`, but its all int-ops, so should be fairly
+    // fast
+    fn is_part_of_poisoned_tree(&self, node_index: NodeIndex) -> bool {
+        for &poisoned_tree_leaf in self.poisoned_tree_leaves.iter() {
+            let mut poisoned_leaf_ancestor = NodeIndex::from(poisoned_tree_leaf);
+            poisoned_leaf_ancestor.move_up_to(node_index.depth());
+            if poisoned_leaf_ancestor == node_index {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl Overlay {
+    pub fn new(current: &Smt, premutated: MutationSet<SMT_DEPTH, Word, Word>) -> Self {
+        todo!()
+        // let mut inverse_mutations = HashMap::new();
+
+        // for (key, _) in set.new_pairs() {
+        //     inverse_mutations.insert(*key, current.get_leaf(key));
+        // }
+
+        // let poisoned_tree_leaves =
+        //     Vec::from_iter(inverse_mutations.values().map(|leaf| leaf.index()));
+
+        // Overlay {
+        //     new_root: preinverted.new_root,
+        //     old_root: preinverted.old_root,
+        //     mutated: preinverted,
+        //     poisoned_tree_leaves,
+        // }
+    }
+
+    /// Create the inversion of the given mutation
+    pub fn inverted(
+        current: &Smt,
+        set: &MutationSet<SMT_DEPTH, Word, Word>,
+    ) -> Result<Self, OverlayError> {
+        let mut inverse_mutations = HashMap::new();
+
+        for (key, _) in set.new_pairs() {
+            inverse_mutations.insert(*key, current.get_leaf(key));
+        }
+
+        let poisoned_tree_leaves =
+            Vec::from_iter(inverse_mutations.values().map(|leaf| leaf.index()));
+
+        // Create and return the inverse mutation set
+        Ok(Overlay {
+            new_root: set.old_root(),
+            old_root: set.root(),
+            mutated: inverse_mutations,
+            poisoned_tree_leaves,
+        })
+    }
+
+    /// Root _pre_ applying the overlay
+    pub fn root(&self) -> Word {
+        self.new_root
+    }
+
+    /// Root _post_ applying the overlay
+    pub fn old_root(&self) -> Word {
+        self.old_root
+    }
+}
+
+// impl From<MutationSet<SMT_DEPTH, Word, Word>> for Overlay {
+//     fn from(value: MutationSet<SMT_DEPTH, Word, Word>) -> Self {
+//         let mutated = HashMap::from_iter(value.new_pairs().map(|(key, _mutation)| {
+//             (key, )
+//         }));
+//         Self {
+//             old_root: value.old_root(),
+//             new_root: value.root(),
+//             mutated,
+//         }
+//     }
+// }
+
+pub type InnerNodeHashCache = HashMap<u32, BTreeMap<NodeIndex, Word>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HistoricalOffset {
+    OverlayIdx(usize),
+    Latest,
+    TooAncient,
+}
+
+#[derive(Debug, Clone)]
+pub struct SmtWithOverlays {
+    /// The tip of the chain `AccountTree`
+    latest: Smt,
+    /// Overlays in order from latest to newest
+    overlays: VecDeque<Overlay>,
+    /// The block number of the oldest overlay
+    base_block_number: u32,
+
+    // TODO use Arc<_>
+    cache: RefCell<InnerNodeHashCache>,
+}
+
+impl SmtWithOverlays {
+    const MAX_OVERLAYS: usize = 33;
+
+    pub fn new(latest: Smt, base_block_number: u32) -> Self {
+        Self {
+            latest,
+            overlays: VecDeque::new(),
+            base_block_number,
+            cache: RefCell::new(Default::default()),
+        }
+    }
+
+    pub fn cleanup(&mut self) {
+        while self.overlays.len() > Self::MAX_OVERLAYS {
+            self.overlays.pop_back();
+        }
+    }
+
+    pub fn oldest(&self) -> u32 {
+        self.base_block_number
+    }
+
+    // obtain the index on the in-memory overlays
+
+    pub fn overlay_idx(latest: u32, requested: u32) -> HistoricalOffset {
+        let Some(idx) = latest.checked_sub(requested) else {
+            return HistoricalOffset::TooAncient;
+        };
+        match idx {
+            0 => HistoricalOffset::Latest,
+            1..33 => HistoricalOffset::OverlayIdx(idx as usize - 1),
+            _ => HistoricalOffset::TooAncient,
+        }
+    }
+
+    /// Construct a new historical view on the account tree, if the relevant overlays are still
+    /// available.
+    pub fn historical_view<'a>(&'a self, height: u32) -> Option<HistoricalTreeView<'a>> {
+        // FIXME use a shared one per height
+        let cache = self.cache.clone();
+        match Self::overlay_idx(self.base_block_number, height) {
+            HistoricalOffset::Latest => Some(HistoricalTreeView {
+                block_number: height,
+                latest: &self.latest,
+                stacks: (&[], &[]),
+                cache,
+            }),
+            HistoricalOffset::OverlayIdx(idx) => Some(HistoricalTreeView {
+                block_number: height,
+                latest: &self.latest,
+                stacks: {
+                    let (a, b) = self.overlays.as_slices();
+                    if a.len() < idx {
+                        (&a[idx..], &b[..])
+                    } else if idx < (a.len() + b.len()) {
+                        (&[], &b[(idx - a.len())..])
+                    } else {
+                        unreachable!("Index must never be out of bounds of combined length")
+                    }
+                },
+                cache,
+            }),
+            HistoricalOffset::TooAncient => None,
+        }
+    }
+
+    /// Add an overlay. Commonly called whenever we apply some new mutations to the _latest_ tree.
+    pub fn add_overlay(&mut self, overlay: Overlay) {
+        self.overlays.push_front(overlay);
+        self.cleanup();
+    }
+}
+
+///Pretend we were still at `block_number` of the `Smt`/`AccountTree`
+pub struct HistoricalTreeView<'a> {
+    block_number: u32,
+    latest: &'a Smt,
+    // 0 is top, nth is bottom, so if we query we query from the top
+    stacks: (&'a [Overlay], &'a [Overlay]),
+
+    cache: RefCell<InnerNodeHashCache>,
+}
+
+impl HistoricalTreeView<'_> {
+    /// An overlay for the stacks
+    fn overlay_iter<'b>(&'b self) -> impl Iterator<Item = &'b Overlay> {
+        self.stacks.0.iter().chain(self.stacks.1.iter())
+    }
+
+    /// Root of all overlays combined with latest.
+    pub fn root(&self) -> Word {
+        self.overlay_iter()
+            .next()
+            .map(|overlay| overlay.root())
+            .unwrap_or_else(|| self.latest.root())
+    }
+
+    /// Wrapper.
+    fn key_to_leaf_index(key: &Word) -> LeafIndex<SMT_DEPTH> {
+        <Smt as SparseMerkleTree<SMT_DEPTH>>::key_to_leaf_index(key)
+    }
+
+    // Dynamically calculate the inner node cache, used for `SmtProof` deduction, and child hashes
+    // required to do so. Call this for every entry in the `MerklePath`.
+    fn recalc_inner_digest_with_cache(
+        &self,
+        index_to_get_value_for: NodeIndex,
+        latest_affected_block_num: u32,
+    ) -> Word {
+        // If we already have the value cached, return it
+        if let Some(&cached_value) = self
+            .cache
+            .borrow_mut()
+            .entry(latest_affected_block_num)
+            .or_default()
+            .get(&index_to_get_value_for)
+        {
+            return cached_value;
+        }
+
+        // Walk down from the target node to find what needs to be computed
+        let mut cache = self.cache.borrow_mut();
+        let digest_cache = cache.entry(latest_affected_block_num).or_default();
+
+        // bfs from the provided index
+        let mut compute_backlog = VecDeque::new();
+        let mut q = VecDeque::new();
+
+        q.push_back(index_to_get_value_for);
+
+        while let Some(current) = q.pop_front() {
+            if digest_cache.contains_key(&current) {
+                continue;
+            } else {
+                if current.depth() == SMT_DEPTH {
+                    // leaves are always available
+                    continue;
+                }
+                compute_backlog.push_back(current);
+
+                // enqueue both again
+                let left = current.left_child();
+                let right = current.left_child();
+                if !digest_cache.contains_key(&left) {
+                    q.push_back(left);
+                }
+                if !digest_cache.contains_key(&right) {
+                    q.push_back(right);
+                }
+            }
+        }
+
+        // Now compute from deepest to lowest
+        while let Some(node) = compute_backlog.pop_back() {
+            let mut cache = self.cache.borrow_mut();
+            let digest_cache = cache.entry(latest_affected_block_num).or_default();
+            if node.depth() == SMT_DEPTH {
+                // Leaf level - get the leaf hash
+                let leaf_index = LeafIndex::<SMT_DEPTH>::new(node.value() as u64).unwrap();
+                let hash = self.get_leaf_hash_at_index(leaf_index);
+                digest_cache.insert(node, hash);
+            } else {
+                // Inner node - compute from children
+                let left = node.left_child();
+                let right = node.right_child();
+
+                // Recursively ensure children are computed
+                let left_hash = if let Some(hash) = digest_cache.get(&left).copied() {
+                    hash
+                } else if left.depth() == SMT_DEPTH {
+                    let leaf_index = LeafIndex::<SMT_DEPTH>::new(left.value() as u64).unwrap();
+                    let hash = self.get_leaf_hash_at_index(leaf_index);
+                    digest_cache.insert(left, hash);
+                    hash
+                } else {
+                    unreachable!("By definition we have computed all previous hashes");
+                };
+
+                let right_hash = if let Some(hash) = digest_cache.get(&right).copied() {
+                    hash
+                } else if right.depth() == SMT_DEPTH {
+                    let leaf_index = LeafIndex::<SMT_DEPTH>::new(right.value() as u64).unwrap();
+                    let hash = self.get_leaf_hash_at_index(leaf_index);
+                    digest_cache.insert(right, hash);
+                    hash
+                } else {
+                    unreachable!("By definition we have computed all previous hashes");
+                };
+
+                let mut cache = self.cache.borrow_mut();
+                let digest_cache = cache.entry(latest_affected_block_num).or_default();
+
+                // Merge the hashes to get parent hash
+                let digest = Rpo256::merge(&[left_hash, right_hash]);
+                digest_cache.insert(node, digest);
+            }
+        }
+
+        let mut cache = self.cache.borrow_mut();
+        let digest_cache = cache.entry(latest_affected_block_num).or_default();
+        digest_cache
+            .get(&index_to_get_value_for)
+            .copied()
+            .expect("We just computed all nodes up to this point")
+    }
+
+    // Helper function to get leaf hash at a specific index
+    fn get_leaf_hash_at_index(&self, leaf_index: LeafIndex<SMT_DEPTH>) -> Word {
+        // Check overlays first
+        for overlay in self.overlay_iter() {
+            for leaf in overlay.mutated.values() {
+                if leaf.index() == leaf_index {
+                    return leaf.hash();
+                }
+            }
+        }
+
+        // Fall back to latest tree
+        let node_index = NodeIndex::from(leaf_index);
+        self.latest.get_node_hash(node_index)
+    }
+
+    /// Returns a [MerklePath] to the specified key.
+    ///
+    /// Mostly this is an implementation detail of [`Self::open()`].
+    fn get_path(&self, key: &Word) -> MerklePath {
+        let index = NodeIndex::from(Self::key_to_leaf_index(key));
+
+        // proof indices include all siblings, so if we want to proof `x`
+        //   root
+        //    / \
+        //  [f]   g
+        //     /  \
+        //    t   [q]
+        //   / \
+        //  x  [y]
+        //
+        //  proof: [y, q, f] (without root! and without the actual leaf!)
+        //
+        //
+        // now we need a way to derive if we can use the `latest.get_node_hash(index)` or _any_
+        // decendent got updated, we are going to call this `is_part_of_poisoned_tree(idx)`
+
+        MerklePath::from_iter(index
+            .proof_indices()
+            // iterates from leaves towards the root
+            .map(|index| { self.get_node_hash(index)
+            }))
+    }
+
+    fn get_inner_node(&self, index: NodeIndex) -> InnerNode {
+        // we know these contain modifications, 'poisoning' the `latest` stack,
+        // so we skip all non-poisoned ones and do lookups from the last poisoning
+        let poison_stack = Vec::from_iter(
+            self.overlay_iter().map(|overlay| overlay.is_part_of_poisoned_tree(index)),
+        );
+
+        if let Some(offset) = poison_stack.iter().position(|&x| x == true) {
+            let latest_affected_block_num = self.block_number.checked_sub(offset as u32)
+                .expect("By definition offset is at most 33 and cannot be larger than the number of blocks produced since genesis");
+            let _ = self.recalc_inner_digest_with_cache(index, latest_affected_block_num);
+            let mut cache = self.cache.borrow_mut();
+            let cache_inner = cache.entry(latest_affected_block_num).or_default();
+            let left = cache_inner.get(&index.left_child()).copied().unwrap();
+            let right = cache_inner.get(&index.right_child()).copied().unwrap();
+            InnerNode { left, right }
+        } else {
+            // nothing touched that index ever
+            self.latest.get_inner_node(index)
+        }
+    }
+
+    /// Get the hash of a node at an arbitrary index, including the root or leaf hashes.
+    ///
+    /// The root index simply returns [`Self::root()`]. Other hashes are retrieved by calling
+    /// [`Self::get_inner_node()`] on the parent, and returning the respective child hash.
+    fn get_node_hash(&self, index: NodeIndex) -> Word {
+        if index.is_root() {
+            return self.root();
+        }
+
+        let InnerNode { left, right } = self.get_inner_node(index.parent());
+
+        let index_is_right = index.is_value_odd();
+        if index_is_right { right } else { left }
+    }
+
+    pub fn get_value(&self, key: &Word) -> Word {
+        match self.get_leaf(key) {
+            SmtLeaf::Single(entry) => {
+                // For single entries, return the value (second element of tuple)
+                return entry.1;
+            },
+            SmtLeaf::Multiple(entries) => {
+                // For multiple entries, find the matching key
+                for entry in entries {
+                    if entry.0 == *key {
+                        return entry.1;
+                    }
+                }
+            },
+            SmtLeaf::Empty(x) => {},
+        }
+        EMPTY_WORD
+    }
+
+    pub fn get_leaf(&self, key: &Word) -> SmtLeaf {
+        for overlay in self.overlay_iter() {
+            if let Some(leaf) = overlay.mutated.get(&key) {
+                if !leaf.is_empty() {
+                    return leaf.clone();
+                }
+            }
+        }
+        self.latest.get_leaf(key)
+    }
+
+    pub fn open(&self, key: &Word) -> SmtProof {
+        let leaf = self.get_leaf(key);
+        let leaf_idx = leaf.index();
+
+        let path = MerklePath::new(Vec::from_iter(
+            leaf_idx.index.proof_indices().map(|idx| self.get_node_hash(idx)),
+        ));
+
+        SmtProof::new(SparseMerklePath::try_from(path).unwrap(), leaf).unwrap()
+    }
+}

--- a/miden-crypto/src/merkle/smt/historical/tests.rs
+++ b/miden-crypto/src/merkle/smt/historical/tests.rs
@@ -1,0 +1,39 @@
+
+use super::*;
+
+
+modtests
+)]#[cfg(test{
+    use super::*;
+    use crate::merkle::{Smt, SmtLeaf};
+    use crate::hash::rpo::RpoDigest;
+
+    // Helper function to create a test key-value pair
+    fn test_pair(n: u64) -> (Word, Word) {
+        let key = RpoDigest::new([n.into(), 0.into(), 0.into(), 0.into()]).into();
+        let value = RpoDigest::new([n.into(), n.into(), 0.into(), 0.into()]).into();
+        (key, value)
+    }
+
+    // Create a mock SMT with some initial data
+    fn create_mock_smt() -> Smt {
+        let mut smt = Smt::new();
+
+        // Insert some initial values
+        for i in 1..=5 {
+            let (key, value) = test_pair(i);
+            smt.insert(key, value);
+        }
+
+        smt
+    }
+
+    // Create test mutation sets
+    fn create_mutation_sets(smt: &Smt) -> (MutationSet<SMT_DEPTH, Word, Word>,
+                                           MutationSet<SMT_DEPTH, Word, Word>,
+                                           MutationSet<SMT_DEPTH, Word, Word>) {
+        // First mutation set: Update existing keys and add new ones
+        let mut smt1 = smt.clone();
+        let old_root1 = smt1.root();
+
+        let (key6, value6) = test_pair(6);xxx

--- a/miden-crypto/src/merkle/smt/mod.rs
+++ b/miden-crypto/src/merkle/smt/mod.rs
@@ -20,6 +20,8 @@ pub use large::{
 };
 #[cfg(feature = "rocksdb")]
 pub use large::{RocksDbConfig, RocksDbStorage};
+// #[cfg(feature = "historical")]
+pub mod historical;
 
 mod simple;
 pub use simple::{SimpleSmt, SimpleSmtProof};


### PR DESCRIPTION
## Describe your changes

Continuation of https://github.com/0xMiden/miden-node/pull/1229 without the operational issues of being out-of-crate.

## Approach

The current approach is to track _inverted_ `MutationSet`s in addition to the _latest_ version of the `Smt`, underpinning an `AccountTree` (not part of this implementation.

Now we do not store inner nodes, but recalculate them (and cache them) on a per block (= set of overlays) basis. We do this by creating a `HistoricalView` and use dynamic programming (~ish) to use the cache as the walk down the children of a desired node index, part of the merkle path, is done.
An additional optimization is performed only checking overlays that actually modify any of the leaves that are able to modify a node index, which is relatively cheap, it's called "poisoning" for now. 

## Left TODOs

* use `Arc<ReadWriteLock<Cache>>` for sharing the same cache for multiple views
* `Overlay::new` is missing an impl
* tests!
* integration with `AccountTree`