### PR TITLE
Validate forest in Mmr::open_at to prevent OOB access

### DIFF
--- a/miden-crypto/src/merkle/mmr/error.rs
+++ b/miden-crypto/src/merkle/mmr/error.rs
@@ -10,8 +10,8 @@ pub enum MmrError {
     PositionNotFound(usize),
     #[error("mmr peaks are invalid: {0}")]
     InvalidPeaks(String),
-    #[error("mmr forest is out of bounds: {0}")]
-    ForestOutOfBounds(String),
+    #[error("mmr forest is out of bounds: requested {0} > current {1}")]
+    ForestOutOfBounds(usize, usize),
     #[error("mmr peak does not match the computed merkle root of the provided authentication path")]
     PeakPathMismatch,
     #[error("requested peak index is {peak_idx} but the number of peaks is {peaks_len}")]

--- a/miden-crypto/src/merkle/mmr/error.rs
+++ b/miden-crypto/src/merkle/mmr/error.rs
@@ -10,6 +10,8 @@ pub enum MmrError {
     PositionNotFound(usize),
     #[error("mmr peaks are invalid: {0}")]
     InvalidPeaks(String),
+    #[error("mmr forest is out of bounds: {0}")]
+    ForestOutOfBounds(String),
     #[error("mmr peak does not match the computed merkle root of the provided authentication path")]
     PeakPathMismatch,
     #[error("requested peak index is {peak_idx} but the number of peaks is {peaks_len}")]

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -97,6 +97,12 @@ impl Mmr {
     /// - The specified leaf position is out of bounds for this MMR.
     /// - The specified `forest` value is not valid for this MMR.
     pub fn open_at(&self, pos: usize, forest: Forest) -> Result<MmrProof, MmrError> {
+        if forest > self.forest {
+            return Err(MmrError::InvalidPeaks(format!(
+                "requested forest {forest} exceeds current forest {}",
+                self.forest
+            )));
+        }
         let (_, path) = self.collect_merkle_path_and_value(pos, forest)?;
 
         Ok(MmrProof {

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -98,10 +98,7 @@ impl Mmr {
     /// - The specified `forest` value is not valid for this MMR.
     pub fn open_at(&self, pos: usize, forest: Forest) -> Result<MmrProof, MmrError> {
         if forest > self.forest {
-            return Err(MmrError::ForestOutOfBounds(format!(
-                "requested forest {forest} exceeds current forest {}",
-                self.forest
-            )));
+            return Err(MmrError::ForestOutOfBounds(forest.num_leaves(), self.forest.num_leaves()));
         }
         let (_, path) = self.collect_merkle_path_and_value(pos, forest)?;
 
@@ -156,10 +153,7 @@ impl Mmr {
     /// Returns an error if the specified `forest` value is not valid for this MMR.
     pub fn peaks_at(&self, forest: Forest) -> Result<MmrPeaks, MmrError> {
         if forest > self.forest {
-            return Err(MmrError::ForestOutOfBounds(format!(
-                "requested forest {forest} exceeds current forest {}",
-                self.forest
-            )));
+            return Err(MmrError::ForestOutOfBounds(forest.num_leaves(), self.forest.num_leaves()));
         }
 
         let peaks: Vec<Word> = TreeSizeIterator::new(forest)
@@ -183,11 +177,17 @@ impl Mmr {
     /// The result is a packed sequence of the authentication elements required to update the trees
     /// that have been merged together, followed by the new peaks of the [Mmr].
     pub fn get_delta(&self, from_forest: Forest, to_forest: Forest) -> Result<MmrDelta, MmrError> {
-        if to_forest > self.forest || from_forest > to_forest {
-            return Err(MmrError::ForestOutOfBounds(format!(
-                "to_forest {to_forest} exceeds the current forest {} or from_forest {from_forest} exceeds to_forest",
-                self.forest
-            )));
+        if to_forest > self.forest {
+            return Err(MmrError::ForestOutOfBounds(
+                to_forest.num_leaves(),
+                self.forest.num_leaves(),
+            ));
+        }
+        if from_forest > to_forest {
+            return Err(MmrError::ForestOutOfBounds(
+                from_forest.num_leaves(),
+                to_forest.num_leaves(),
+            ));
         }
 
         if from_forest == to_forest {

--- a/miden-crypto/src/merkle/mmr/full.rs
+++ b/miden-crypto/src/merkle/mmr/full.rs
@@ -98,7 +98,7 @@ impl Mmr {
     /// - The specified `forest` value is not valid for this MMR.
     pub fn open_at(&self, pos: usize, forest: Forest) -> Result<MmrProof, MmrError> {
         if forest > self.forest {
-            return Err(MmrError::InvalidPeaks(format!(
+            return Err(MmrError::ForestOutOfBounds(format!(
                 "requested forest {forest} exceeds current forest {}",
                 self.forest
             )));
@@ -156,7 +156,7 @@ impl Mmr {
     /// Returns an error if the specified `forest` value is not valid for this MMR.
     pub fn peaks_at(&self, forest: Forest) -> Result<MmrPeaks, MmrError> {
         if forest > self.forest {
-            return Err(MmrError::InvalidPeaks(format!(
+            return Err(MmrError::ForestOutOfBounds(format!(
                 "requested forest {forest} exceeds current forest {}",
                 self.forest
             )));
@@ -184,7 +184,7 @@ impl Mmr {
     /// that have been merged together, followed by the new peaks of the [Mmr].
     pub fn get_delta(&self, from_forest: Forest, to_forest: Forest) -> Result<MmrDelta, MmrError> {
         if to_forest > self.forest || from_forest > to_forest {
-            return Err(MmrError::InvalidPeaks(format!(
+            return Err(MmrError::ForestOutOfBounds(format!(
                 "to_forest {to_forest} exceeds the current forest {} or from_forest {from_forest} exceeds to_forest",
                 self.forest
             )));


### PR DESCRIPTION
## Describe your changes


Add a guard ensuring the requested forest does not exceed self.forest before building the Merkle path. This aligns open_at with existing validation in peaks_at and get_delta, and prevents potential out-of-bounds indexing and panics when callers pass an invalid forest.